### PR TITLE
fix: restore clean builds after merged PR updates

### DIFF
--- a/apps/api/src/app/api/reports/dashboard/route.ts
+++ b/apps/api/src/app/api/reports/dashboard/route.ts
@@ -1,11 +1,119 @@
-// Import necessary modules
-import { prisma } from '../../../prisma';
+﻿import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { hasPermission, isSuperAdmin } from '@/lib/rbac'
 
-// Base where condition
-const baseWhere = { ... }; // Presuming baseWhere is defined somewhere else in the file
+export async function OPTIONS() {
+  return handleOptions()
+}
 
-export async function getTotalProducts() {
-  return await prisma.product.findMany({
-    where: { ...baseWhere, status: 'ACTIVE' },
-  }).then(products => products.length);
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!hasPermission(user, 'view:analytics')) return apiError('Forbidden', 403)
+
+    const tenantId = isSuperAdmin(user)
+      ? new URL(req.url).searchParams.get('tenantId') || undefined
+      : user.tenantId!
+
+    const subsidiaryId = new URL(req.url).searchParams.get('subsidiaryId') || undefined
+
+    const baseWhere = {
+      tenantId,
+      archived: false,
+      ...(subsidiaryId ? { subsidiaryId } : {}),
+    }
+
+    const now = new Date()
+
+    // Today's date range
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0)
+    const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999)
+
+    // This month's start
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+
+    // Build the 7-day trend date ranges (oldest first)
+    const trendDays = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - (6 - i))
+      return {
+        date: d.toISOString().slice(0, 10),
+        start: new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0),
+        end: new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999),
+      }
+    })
+
+    // All aggregates fired in parallel ΓÇö single round-trip batch
+    const [
+      [todaySales, monthSales, monthExpenses, allActiveProducts, activeSubsidiaries, unreadNotifications],
+      trendAggregates,
+    ] = await Promise.all([
+      Promise.all([
+        // Today's sales (count + total)
+        prisma.sale.aggregate({
+          where: { ...baseWhere, createdAt: { gte: todayStart, lte: todayEnd } },
+          _sum: { totalAmount: true },
+          _count: { id: true },
+        }),
+        // This month's revenue
+        prisma.sale.aggregate({
+          where: { ...baseWhere, createdAt: { gte: monthStart } },
+          _sum: { totalAmount: true },
+        }),
+        // This month's expenses
+        prisma.expense.aggregate({
+          where: { ...baseWhere, date: { gte: monthStart } },
+          _sum: { amount: true },
+        }),
+        // All non-archived products ΓÇö used for both totalProducts and lowStockCount
+        // (Prisma doesn't support column-vs-column comparisons, so we filter in app)
+        prisma.product.findMany({
+           where: { ...baseWhere, status: 'ACTIVE' },
+          select: { quantity: true, lowStockThreshold: true, status: true },
+        }),
+        // Active subsidiaries count
+        prisma.subsidiary.count({ where: { tenantId, archived: false, isActive: true } }),
+        // Unread notifications count
+        prisma.notification.count({ where: { tenantId, isRead: false } }),
+      ]),
+      // 7-day sales trend (one aggregate per day, fired in parallel with the main queries)
+      Promise.all(
+        trendDays.map(({ start, end }) =>
+          prisma.sale.aggregate({
+            where: { ...baseWhere, createdAt: { gte: start, lte: end } },
+            _sum: { totalAmount: true },
+          })
+        )
+      ),
+    ])
+
+    // Derive product stats from the single products query
+    const totalProducts = allActiveProducts.length  // all are ACTIVE (filtered in query)
+    const lowStockCount = allActiveProducts.filter(
+      (p) => Number(p.quantity) <= Number(p.lowStockThreshold)
+    ).length
+
+    // Map trend aggregates back to { date, revenue } ΓÇö zero-filled for days with no sales
+    const salesTrend = trendDays.map(({ date }, i) => ({
+      date,
+      revenue: Number(trendAggregates[i]._sum.totalAmount || 0),
+    }))
+
+    return NextResponse.json({
+      data: {
+        todaySalesCount: todaySales._count.id,
+        todaySalesTotal: Number(todaySales._sum.totalAmount || 0),
+        revenueThisMonth: Number(monthSales._sum.totalAmount || 0),
+        expensesThisMonth: Number(monthExpenses._sum.amount || 0),
+        totalProducts,
+        lowStockCount,
+        activeSubsidiaries,
+        unreadNotifications,
+        salesTrend,
+      },
+    })
+  } catch (err) {
+    console.error('[DASHBOARD GET]', err)
+    return apiError('Internal server error', 500)
+  }
 }

--- a/apps/api/src/app/api/sales/route.ts
+++ b/apps/api/src/app/api/sales/route.ts
@@ -18,7 +18,7 @@ const createSaleSchema = z.object({
   subsidiaryId: z.string(),
   items: z.array(saleItemSchema).min(1),
   discount: z.number().min(0).default(0),
-  paymentMethod: z.enum(['CASH', 'CARD', 'TRANSFER', 'POS']).default('CASH'),
+  paymentMethod: z.enum(['CASH', 'TRANSFER', 'POS']).default('CASH'),
   amountPaid: z.number().min(0),
   notes: z.string().optional(),
 })

--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Table } from 'dexie'
-import type { Product, Expense, CartItem, SaleCheckoutPayload } from '@/types'
+import type { Product, Expense, CartItem, Sale, SaleCheckoutPayload } from '@/types'
 
 export interface ExpensePayload {
   title: string
@@ -24,7 +24,7 @@ export class StockPilotDB extends Dexie {
   products!: Table<Product>
   sales!: Table<Sale>
   expenses!: Table<Expense>
-  pendingRecords!: Table<PendingRecord<SalePayload | ExpensePayload>>
+  pendingRecords!: Table<PendingRecord<SaleCheckoutPayload | ExpensePayload>>
   cart!: Table<CartItem & { id: number }>
 
   constructor() {

--- a/apps/client/src/pages/Sales.tsx
+++ b/apps/client/src/pages/Sales.tsx
@@ -285,7 +285,6 @@ export default function SalesPage() {
         <div className="flex-1 flex flex-col min-w-0">
           <div className="flex items-center justify-between mb-4">
             <h1 className="text-xl font-bold text-gray-900">Point of Sale</h1>
-            <div className="flex items-center gap-2 text-xs text-gray-400">
             <div className={`flex items-center gap-2 text-xs transition-colors duration-200 ${
               scanState === 'success' ? 'text-success-600' :
               scanState === 'error' ? 'text-danger-500' :


### PR DESCRIPTION
## Summary
This PR fixes four regressions discovered after pulling the recently merged Copilot PRs to local main.

## Changes
- restore the full dashboard stats route and keep totalProducts scoped to ACTIVE products
- align sales API paymentMethod validation with the Prisma enum used by the backend
- fix stale client Dexie type references in apps/client/src/lib/db.ts
- remove the malformed duplicate barcode status wrapper in the Sales page JSX

## Validation
- npm run build --workspace=apps/api
- npm run build --workspace=apps/client