### PR TITLE
feat(sync): server-side telemetry for remote health

### DIFF
--- a/apps/api/prisma/migrations/20260402093000_add_sync_telemetry/migration.sql
+++ b/apps/api/prisma/migrations/20260402093000_add_sync_telemetry/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "SyncTelemetry" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "subsidiaryId" TEXT,
+    "userId" TEXT,
+    "deviceId" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'web',
+    "status" TEXT NOT NULL,
+    "pendingBefore" INTEGER NOT NULL DEFAULT 0,
+    "syncedCount" INTEGER NOT NULL DEFAULT 0,
+    "failedCount" INTEGER NOT NULL DEFAULT 0,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SyncTelemetry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SyncTelemetry_tenantId_createdAt_idx" ON "SyncTelemetry"("tenantId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SyncTelemetry_tenantId_deviceId_createdAt_idx" ON "SyncTelemetry"("tenantId", "deviceId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SyncTelemetry_tenantId_status_createdAt_idx" ON "SyncTelemetry"("tenantId", "status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "SyncTelemetry" ADD CONSTRAINT "SyncTelemetry_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SyncTelemetry" ADD CONSTRAINT "SyncTelemetry_subsidiaryId_fkey" FOREIGN KEY ("subsidiaryId") REFERENCES "Subsidiary"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SyncTelemetry" ADD CONSTRAINT "SyncTelemetry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Tenant {
   auditLogs       AuditLog[]
   ssoAccounts     SsoAccount[]
   currencyRates   CurrencyRate[]
+  syncTelemetry   SyncTelemetry[]
 }
 
 // ──────────────────────────────────────────────
@@ -163,6 +164,7 @@ model User {
   damageRecords   DamageRecord[] @relation("DamageRecords")
   refreshTokens   RefreshToken[]
   ssoAccounts     SsoAccount[]
+  syncTelemetry   SyncTelemetry[]
 
   @@index([tenantId])
   @@index([email])
@@ -235,6 +237,7 @@ model Subsidiary {
   sales           Sale[]
   expenses        Expense[]
   damageRecords   DamageRecord[]
+  syncTelemetry   SyncTelemetry[]
 
   @@index([tenantId])
 }
@@ -365,6 +368,29 @@ model Expense {
   @@index([subsidiaryId])
   @@index([date])
   @@unique([tenantId, syncRef])
+}
+
+model SyncTelemetry {
+  id            String    @id @default(cuid())
+  tenantId      String
+  subsidiaryId  String?
+  userId        String?
+  deviceId      String
+  source        String    @default("web")
+  status        String
+  pendingBefore Int       @default(0)
+  syncedCount   Int       @default(0)
+  failedCount   Int       @default(0)
+  error         String?
+  createdAt     DateTime  @default(now())
+
+  tenant        Tenant     @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  subsidiary    Subsidiary? @relation(fields: [subsidiaryId], references: [id], onDelete: SetNull)
+  user          User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([tenantId, createdAt])
+  @@index([tenantId, deviceId, createdAt])
+  @@index([tenantId, status, createdAt])
 }
 
 // ──────────────────────────────────────────────

--- a/apps/api/src/app/api/sync/telemetry/route.ts
+++ b/apps/api/src/app/api/sync/telemetry/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { hasPermission, isSuperAdmin } from '@/lib/rbac'
+
+const postSchema = z.object({
+  deviceId: z.string().trim().min(1).max(120),
+  source: z.string().trim().min(1).max(32).optional(),
+  status: z.enum(['success', 'partial', 'failed', 'noop']),
+  pendingBefore: z.number().int().min(0).default(0),
+  syncedCount: z.number().int().min(0).default(0),
+  failedCount: z.number().int().min(0).default(0),
+  error: z.string().max(500).optional(),
+  subsidiaryId: z.string().trim().optional(),
+})
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!user.tenantId) return apiError('No tenant context for this account.', 400)
+
+    const body = await req.json()
+    const payload = postSchema.parse(body)
+
+    const subsidiaryId = user.subsidiaryId || payload.subsidiaryId || null
+
+    const telemetry = await prisma.syncTelemetry.create({
+      data: {
+        tenantId: user.tenantId,
+        subsidiaryId,
+        userId: user.userId,
+        deviceId: payload.deviceId,
+        source: payload.source || 'web',
+        status: payload.status,
+        pendingBefore: payload.pendingBefore,
+        syncedCount: payload.syncedCount,
+        failedCount: payload.failedCount,
+        error: payload.error,
+      },
+      select: { id: true, createdAt: true },
+    })
+
+    return NextResponse.json({ data: telemetry }, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    console.error('[SYNC TELEMETRY POST]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!hasPermission(user, 'view:reports')) return apiError('Forbidden', 403)
+
+    const { searchParams } = new URL(req.url)
+    const requestedTenantId = searchParams.get('tenantId') || undefined
+    const tenantId = isSuperAdmin(user)
+      ? requestedTenantId || user.tenantId!
+      : user.tenantId!
+
+    if (!tenantId) return apiError('No tenant context for this account. Provide tenantId.', 400)
+
+    const from = searchParams.get('from')
+    const to = searchParams.get('to')
+    const limit = Math.min(500, Math.max(1, Number(searchParams.get('limit') || 100)))
+    const deviceId = searchParams.get('deviceId') || undefined
+    const status = searchParams.get('status') || undefined
+    const subsidiaryId = searchParams.get('subsidiaryId') || undefined
+
+    const createdAt = from || to
+      ? {
+          ...(from ? { gte: new Date(from) } : {}),
+          ...(to ? { lte: new Date(to) } : {}),
+        }
+      : undefined
+
+    const where = {
+      tenantId,
+      ...(deviceId ? { deviceId } : {}),
+      ...(status ? { status } : {}),
+      ...(subsidiaryId ? { subsidiaryId } : {}),
+      ...(createdAt ? { createdAt } : {}),
+    }
+
+    const rows = await prisma.syncTelemetry.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        deviceId: true,
+        source: true,
+        status: true,
+        pendingBefore: true,
+        syncedCount: true,
+        failedCount: true,
+        error: true,
+        createdAt: true,
+        subsidiary: { select: { id: true, name: true } },
+        user: { select: { id: true, firstName: true, lastName: true, email: true } },
+      },
+    })
+
+    const summary = rows.reduce(
+      (acc, row) => {
+        acc.totalRuns += 1
+        acc.syncedCount += row.syncedCount
+        acc.failedCount += row.failedCount
+        if (row.status === 'success') acc.successRuns += 1
+        if (row.status === 'partial') acc.partialRuns += 1
+        if (row.status === 'failed') acc.failedRuns += 1
+        if (row.status === 'noop') acc.noopRuns += 1
+        return acc
+      },
+      {
+        totalRuns: 0,
+        successRuns: 0,
+        partialRuns: 0,
+        failedRuns: 0,
+        noopRuns: 0,
+        syncedCount: 0,
+        failedCount: 0,
+      }
+    )
+
+    return NextResponse.json({ data: { summary, rows } })
+  } catch (err) {
+    console.error('[SYNC TELEMETRY GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/client/src/lib/sync.ts
+++ b/apps/client/src/lib/sync.ts
@@ -31,6 +31,32 @@ let syncStatus: SyncStatus = {
 }
 let syncHistory: SyncHistoryEntry[] = []
 
+function getSyncDeviceId() {
+  if (typeof window === 'undefined') return 'server'
+  const key = 'stockpilot:sync-device-id'
+  const existing = window.localStorage.getItem(key)
+  if (existing) return existing
+  const next = `device_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+  window.localStorage.setItem(key, next)
+  return next
+}
+
+async function sendSyncTelemetry(entry: SyncHistoryEntry) {
+  try {
+    await api.post('/sync/telemetry', {
+      deviceId: getSyncDeviceId(),
+      source: 'web',
+      status: entry.status,
+      pendingBefore: entry.pendingBefore,
+      syncedCount: entry.syncedCount,
+      failedCount: entry.failedCount,
+      error: entry.error,
+    })
+  } catch {
+    // Telemetry must never block local sync behavior.
+  }
+}
+
 function shouldPersistSyncHistory(entry: SyncHistoryEntry) {
   // Ignore empty runs to keep history focused on meaningful sync activity.
   return entry.pendingBefore > 0 || entry.syncedCount > 0 || entry.failedCount > 0 || entry.status === 'failed'
@@ -109,13 +135,15 @@ export async function syncPendingRecords() {
         lastSyncedCount: 0,
         lastFailedCount: 0,
       }
-      pushSyncHistory({
+      const entry: SyncHistoryEntry = {
         at: Date.now(),
         syncedCount: 0,
         failedCount: 0,
         pendingBefore: 0,
         status: 'noop',
-      })
+      }
+      pushSyncHistory(entry)
+      void sendSyncTelemetry(entry)
       emitSyncStatus()
       return
     }
@@ -154,14 +182,16 @@ export async function syncPendingRecords() {
       lastFailedCount: failed,
       lastError: failed > 0 ? `${failed} record(s) failed to sync` : null,
     }
-    pushSyncHistory({
+    const entry: SyncHistoryEntry = {
       at: Date.now(),
       syncedCount: synced,
       failedCount: failed,
       pendingBefore: pending.length,
       status: failed === 0 ? 'success' : synced > 0 ? 'partial' : 'failed',
       error: failed > 0 ? `${failed} record(s) failed to sync` : undefined,
-    })
+    }
+    pushSyncHistory(entry)
+    void sendSyncTelemetry(entry)
     emitSyncStatus()
   } catch (err) {
     syncStatus = {
@@ -170,14 +200,16 @@ export async function syncPendingRecords() {
       lastSyncAt: Date.now(),
       lastError: (err as Error)?.message || 'Sync failed',
     }
-    pushSyncHistory({
+    const entry: SyncHistoryEntry = {
       at: Date.now(),
       syncedCount: 0,
       failedCount: 0,
       pendingBefore: 0,
       status: 'failed',
       error: (err as Error)?.message || 'Sync failed',
-    })
+    }
+    pushSyncHistory(entry)
+    void sendSyncTelemetry(entry)
     emitSyncStatus()
     throw err
   } finally {


### PR DESCRIPTION
Implements issue #100.\n\n- Adds SyncTelemetry model + migration\n- Adds POST/GET /api/sync/telemetry for ingest and admin inspection\n- Emits telemetry from client sync loop with device identifier\n\nCloses #100