### PR TITLE
feat(sync): advanced idempotency for duplicate prevention

### DIFF
--- a/apps/api/prisma/migrations/20260402102000_add_transaction_ref_idempotency/migration.sql
+++ b/apps/api/prisma/migrations/20260402102000_add_transaction_ref_idempotency/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Sale" ADD COLUMN "transactionRef" TEXT;
+ALTER TABLE "Expense" ADD COLUMN "transactionRef" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sale_tenantId_transactionRef_key" ON "Sale"("tenantId", "transactionRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Expense_tenantId_transactionRef_key" ON "Expense"("tenantId", "transactionRef");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -297,6 +297,7 @@ model Sale {
   currency        String        @default("USD")
   fxRate          Decimal       @db.Decimal(18, 8) @default(1)
   syncRef         String?
+  transactionRef  String?
   notes           String?
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
@@ -314,6 +315,7 @@ model Sale {
   @@index([userId])
   @@index([createdAt])
   @@unique([tenantId, syncRef])
+  @@unique([tenantId, transactionRef])
 }
 
 // ──────────────────────────────────────────────
@@ -353,6 +355,7 @@ model Expense {
   currency        String    @default("USD")
   fxRate          Decimal   @db.Decimal(18, 8) @default(1)
   syncRef         String?
+  transactionRef  String?
   notes           String?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
@@ -368,6 +371,7 @@ model Expense {
   @@index([subsidiaryId])
   @@index([date])
   @@unique([tenantId, syncRef])
+  @@unique([tenantId, transactionRef])
 }
 
 model SyncTelemetry {

--- a/apps/api/src/app/api/expenses/route.ts
+++ b/apps/api/src/app/api/expenses/route.ts
@@ -14,6 +14,7 @@ const createSchema = z.object({
   currency: z.string().length(3).transform((v) => v.toUpperCase()).default('USD'),
   fxRate: z.number().positive().default(1),
   syncRef: z.string().min(6).max(120).optional(),
+  transactionRef: z.string().min(6).max(180).optional(),
   notes: z.string().optional(),
   subsidiaryId: z.string(),
 })
@@ -85,18 +86,29 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  let tenantId: string | undefined
+  let idempotencyRef: string | undefined
   try {
     const user = authenticate(req)
+    tenantId = user.tenantId || undefined
     const body = await req.json()
     const data = createSchema.parse(body)
     const syncRef = data.syncRef?.trim() || undefined
+    const transactionRef = data.transactionRef?.trim() || undefined
+    idempotencyRef = transactionRef || syncRef
 
     assertSubsidiaryAccess(user, data.subsidiaryId)
 
-    // Idempotency guard for offline replay: if already synced, return existing expense.
-    if (syncRef) {
+    // Strong idempotency guard: prefer transactionRef, fallback to syncRef.
+    if (idempotencyRef) {
       const existing = await prisma.expense.findFirst({
-        where: { tenantId: user.tenantId!, syncRef },
+        where: {
+          tenantId: user.tenantId!,
+          OR: [
+            { transactionRef: idempotencyRef },
+            { syncRef: idempotencyRef },
+          ],
+        },
       })
       if (existing) {
         return NextResponse.json({ data: existing })
@@ -107,6 +119,7 @@ export async function POST(req: NextRequest) {
       data: {
         ...data,
         syncRef,
+        transactionRef,
         date: new Date(data.date),
         tenantId: user.tenantId!,
         userId: user.userId,
@@ -128,6 +141,7 @@ export async function POST(req: NextRequest) {
         currency: expense.currency,
         fxRate: expense.fxRate,
         syncRef: expense.syncRef,
+        transactionRef: expense.transactionRef,
         subsidiaryId: expense.subsidiaryId,
       },
       req,
@@ -137,6 +151,20 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    if ((err as { code?: string }).code === 'P2002') {
+      if (idempotencyRef && tenantId) {
+        const existing = await prisma.expense.findFirst({
+          where: {
+            tenantId,
+            OR: [
+              { transactionRef: idempotencyRef },
+              { syncRef: idempotencyRef },
+            ],
+          },
+        })
+        if (existing) return NextResponse.json({ data: existing })
+      }
+    }
     console.error('[EXPENSES POST]', err)
     return apiError('Internal server error', 500)
   }

--- a/apps/api/src/app/api/sales/route.ts
+++ b/apps/api/src/app/api/sales/route.ts
@@ -23,6 +23,7 @@ const createSaleSchema = z.object({
   currency: z.string().length(3).transform((v) => v.toUpperCase()).default('USD'),
   fxRate: z.number().positive().default(1),
   syncRef: z.string().min(6).max(120).optional(),
+  transactionRef: z.string().min(6).max(180).optional(),
   notes: z.string().optional(),
 })
 
@@ -96,18 +97,29 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  let tenantId: string | undefined
+  let idempotencyRef: string | undefined
   try {
     const user = authenticate(req)
+    tenantId = user.tenantId || undefined
     const body = await req.json()
     const data = createSaleSchema.parse(body)
     const syncRef = data.syncRef?.trim() || undefined
+    const transactionRef = data.transactionRef?.trim() || undefined
+    idempotencyRef = transactionRef || syncRef
 
     assertSubsidiaryAccess(user, data.subsidiaryId)
 
-    // Idempotency guard for offline replay: if already synced, return the existing sale.
-    if (syncRef) {
+    // Strong idempotency guard: prefer transactionRef, fallback to syncRef.
+    if (idempotencyRef) {
       const existing = await prisma.sale.findFirst({
-        where: { tenantId: user.tenantId!, syncRef },
+        where: {
+          tenantId: user.tenantId!,
+          OR: [
+            { transactionRef: idempotencyRef },
+            { syncRef: idempotencyRef },
+          ],
+        },
         include: {
           items: {
             include: { product: { select: { name: true, unit: true } } },
@@ -178,6 +190,7 @@ export async function POST(req: NextRequest) {
           currency: data.currency,
           fxRate: data.fxRate,
           syncRef,
+          transactionRef,
           receiptNumber,
           notes: data.notes,
           createdBy: user.userId,
@@ -219,6 +232,7 @@ export async function POST(req: NextRequest) {
         currency: sale.currency,
         fxRate: sale.fxRate,
         syncRef: sale.syncRef,
+        transactionRef: sale.transactionRef,
         subsidiaryId: sale.subsidiaryId,
         itemsCount: sale.items.length,
       },
@@ -229,6 +243,26 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    if ((err as { code?: string }).code === 'P2002') {
+      if (idempotencyRef && tenantId) {
+        const existing = await prisma.sale.findFirst({
+          where: {
+            tenantId,
+            OR: [
+              { transactionRef: idempotencyRef },
+              { syncRef: idempotencyRef },
+            ],
+          },
+          include: {
+            items: {
+              include: { product: { select: { name: true, unit: true } } },
+            },
+            user: { select: { firstName: true, lastName: true } },
+          },
+        })
+        if (existing) return NextResponse.json({ data: existing })
+      }
+    }
     console.error('[SALES POST]', err)
     return apiError('Internal server error', 500)
   }

--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -9,6 +9,7 @@ export interface ExpensePayload {
   notes?: string
   subsidiaryId: string
   syncRef?: string
+  transactionRef?: string
 }
 
 // Offline-pending record wrapper
@@ -87,7 +88,12 @@ export async function getProductByBarcode(barcode: string): Promise<Product | un
 
 export async function addPendingSale(data: SaleCheckoutPayload) {
   const localId = `local_${Date.now()}_${Math.random().toString(36).slice(2)}`
-  const payload: SaleCheckoutPayload = { ...data, syncRef: data.syncRef || localId }
+  const dedupeRef = data.transactionRef || data.syncRef || localId
+  const payload: SaleCheckoutPayload = {
+    ...data,
+    syncRef: data.syncRef || localId,
+    transactionRef: dedupeRef,
+  }
   await db.pendingRecords.add({
     localId,
     type: 'sale',
@@ -100,7 +106,12 @@ export async function addPendingSale(data: SaleCheckoutPayload) {
 
 export async function addPendingExpense(data: ExpensePayload) {
   const localId = `local_${Date.now()}_${Math.random().toString(36).slice(2)}`
-  const payload: ExpensePayload = { ...data, syncRef: data.syncRef || localId }
+  const dedupeRef = data.transactionRef || data.syncRef || localId
+  const payload: ExpensePayload = {
+    ...data,
+    syncRef: data.syncRef || localId,
+    transactionRef: dedupeRef,
+  }
   await db.pendingRecords.add({
     localId,
     type: 'expense',

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -96,6 +96,7 @@ export interface SaleCheckoutPayload {
   currency: string
   fxRate: number
   syncRef?: string
+  transactionRef?: string
   notes?: string
   items: {
     productId: string


### PR DESCRIPTION
Implements issue #101.\n\n- Adds transactionRef uniqueness for sales/expenses per tenant\n- Uses transactionRef/syncRef dedupe guards in sales and expenses APIs\n- Adds race-safe P2002 fallback returning existing records\n- Emits stronger transaction references from offline pending payload creation\n\nCloses #101