### PR TITLE
feat(users): stale-user activity alerts

### DIFF
--- a/apps/api/src/app/api/users/stale-alerts/route.ts
+++ b/apps/api/src/app/api/users/stale-alerts/route.ts
@@ -1,0 +1,186 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { isSuperAdmin, requirePermission } from '@/lib/rbac'
+
+type StaleUser = {
+  id: string
+  email: string
+  firstName: string
+  lastName: string
+  lastSeenAt: Date | null
+  thresholdHours: number
+  hoursSinceLastSeen: number
+}
+
+function parseThresholdHours(value?: string | null): number[] {
+  const raw = (value || '24,72').split(',').map((v) => Number(v.trim())).filter((v) => Number.isFinite(v) && v > 0)
+  const unique = Array.from(new Set(raw)).sort((a, b) => a - b)
+  return unique.length > 0 ? unique : [24, 72]
+}
+
+function getStaleThreshold(hoursSinceLastSeen: number, thresholds: number[]): number | null {
+  let exceeded: number | null = null
+  for (const threshold of thresholds) {
+    if (hoursSinceLastSeen >= threshold) exceeded = threshold
+  }
+  return exceeded
+}
+
+function buildStaleUsers(users: Array<{ id: string; email: string; firstName: string; lastName: string; lastSeenAt: Date | null }>, thresholds: number[]): StaleUser[] {
+  const now = Date.now()
+  const stale: StaleUser[] = []
+
+  for (const user of users) {
+    const lastSeenMs = user.lastSeenAt ? new Date(user.lastSeenAt).getTime() : 0
+    const hoursSinceLastSeen = lastSeenMs > 0 ? Math.floor((now - lastSeenMs) / (1000 * 60 * 60)) : 24 * 365
+    const thresholdHours = getStaleThreshold(hoursSinceLastSeen, thresholds)
+    if (!thresholdHours) continue
+
+    stale.push({
+      ...user,
+      thresholdHours,
+      hoursSinceLastSeen,
+    })
+  }
+
+  return stale.sort((a, b) => b.hoursSinceLastSeen - a.hoursSinceLastSeen)
+}
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'manage:users')
+
+    const { searchParams } = new URL(req.url)
+    const requestedTenantId = searchParams.get('tenantId') || undefined
+    const thresholds = parseThresholdHours(searchParams.get('hours'))
+
+    const tenantId = isSuperAdmin(user)
+      ? requestedTenantId || user.tenantId!
+      : user.tenantId!
+
+    if (!tenantId) {
+      return apiError('No tenant context for this account. Provide tenantId.', 400)
+    }
+
+    const users = await prisma.user.findMany({
+      where: {
+        tenantId,
+        archived: false,
+        role: 'SALESPERSON',
+        isActive: true,
+      },
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        lastSeenAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    const staleUsers = buildStaleUsers(users, thresholds)
+
+    return NextResponse.json({
+      data: {
+        thresholds,
+        staleCount: staleUsers.length,
+        staleUsers,
+      },
+    })
+  } catch (err) {
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    if ((err as Error).message === 'Unauthorized') return apiError('Unauthorized', 401)
+    console.error('[STALE USERS GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'manage:users')
+
+    const { searchParams } = new URL(req.url)
+    const requestedTenantId = searchParams.get('tenantId') || undefined
+    const thresholds = parseThresholdHours(searchParams.get('hours'))
+
+    const tenantId = isSuperAdmin(user)
+      ? requestedTenantId || user.tenantId!
+      : user.tenantId!
+
+    if (!tenantId) {
+      return apiError('No tenant context for this account. Provide tenantId.', 400)
+    }
+
+    const users = await prisma.user.findMany({
+      where: {
+        tenantId,
+        archived: false,
+        role: 'SALESPERSON',
+        isActive: true,
+      },
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        lastSeenAt: true,
+      },
+    })
+
+    const staleUsers = buildStaleUsers(users, thresholds)
+    if (staleUsers.length === 0) {
+      return NextResponse.json({ data: { sent: 0, skipped: 0 } })
+    }
+
+    const now = new Date()
+    const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+
+    let sent = 0
+    let skipped = 0
+
+    for (const staleUser of staleUsers) {
+      const dedupeKey = `STALE_USER:${staleUser.id}:${staleUser.thresholdHours}:${dayStart.toISOString().slice(0, 10)}`
+
+      const existing = await prisma.notification.findFirst({
+        where: {
+          tenantId,
+          type: 'SYSTEM',
+          createdAt: { gte: dayStart },
+          message: { contains: dedupeKey },
+        },
+        select: { id: true },
+      })
+
+      if (existing) {
+        skipped += 1
+        continue
+      }
+
+      await prisma.notification.create({
+        data: {
+          tenantId,
+          type: 'SYSTEM',
+          title: `Inactive salesperson (${staleUser.thresholdHours}h+)`,
+          message: `${staleUser.firstName} ${staleUser.lastName} has not been seen for ${staleUser.hoursSinceLastSeen} hours. ${dedupeKey}`,
+        },
+      })
+
+      sent += 1
+    }
+
+    return NextResponse.json({ data: { sent, skipped } })
+  } catch (err) {
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    if ((err as Error).message === 'Unauthorized') return apiError('Unauthorized', 401)
+    console.error('[STALE USERS POST]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/client/src/pages/Users.tsx
+++ b/apps/client/src/pages/Users.tsx
@@ -102,6 +102,10 @@ export default function Users() {
   const [saving, setSaving] = useState(false)
   const [salespersonsOnly, setSalespersonsOnly] = useState(false)
   const [onlineOnly, setOnlineOnly] = useState(false)
+  const [staleHours, setStaleHours] = useState(24)
+  const [staleLoading, setStaleLoading] = useState(false)
+  const [sendingStaleAlerts, setSendingStaleAlerts] = useState(false)
+  const [staleUsers, setStaleUsers] = useState<Array<{ id: string; firstName: string; lastName: string; hoursSinceLastSeen: number; thresholdHours: number }>>([])
 
   const canManage = currentUser?.role === 'BUSINESS_ADMIN' || currentUser?.role === 'SUPER_ADMIN'
   const isBusinessAdmin = currentUser?.role === 'BUSINESS_ADMIN'
@@ -125,6 +129,36 @@ export default function Users() {
   }
 
   useEffect(() => { load() }, [])
+
+  const loadStaleUsers = async () => {
+    if (!canManage) return
+    setStaleLoading(true)
+    try {
+      const res = await api.get<{ data: { staleUsers: Array<{ id: string; firstName: string; lastName: string; hoursSinceLastSeen: number; thresholdHours: number }> } }>(`/users/stale-alerts?hours=${staleHours}`)
+      setStaleUsers(res.data.data.staleUsers || [])
+    } catch {
+      setStaleUsers([])
+    } finally {
+      setStaleLoading(false)
+    }
+  }
+
+  const sendStaleAlerts = async () => {
+    setSendingStaleAlerts(true)
+    try {
+      const res = await api.post<{ data: { sent: number; skipped: number } }>(`/users/stale-alerts?hours=${staleHours}`)
+      toast.success(`Sent ${res.data.data.sent} stale-user alert(s), skipped ${res.data.data.skipped}.`)
+      await loadStaleUsers()
+    } catch {
+      toast.error('Failed to send stale-user alerts')
+    } finally {
+      setSendingStaleAlerts(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadStaleUsers()
+  }, [staleHours, canManage])
 
   const openCreate = () => { setForm(emptyForm); setModal({ open: true, user: null }) }
   const openEdit = (u: AuthUser) => {
@@ -170,6 +204,40 @@ export default function Users() {
           Online now only
         </button>
       </div>
+
+      {canManage && (
+        <div className="rounded-xl border border-amber-100 bg-amber-50/60 p-4 space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-sm font-semibold text-amber-900">Stale Salesperson Activity</p>
+              <p className="text-xs text-amber-800">
+                {staleLoading ? 'Checking activity...' : `${staleUsers.length} salesperson(s) inactive for ${staleHours}+ hours`}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <select
+                className="input text-xs py-1.5 px-2"
+                value={staleHours}
+                onChange={(e) => setStaleHours(Number(e.target.value))}
+              >
+                <option value={24}>24h threshold</option>
+                <option value={72}>72h threshold</option>
+              </select>
+              <button onClick={sendStaleAlerts} disabled={sendingStaleAlerts} className="btn-secondary text-xs">
+                {sendingStaleAlerts && <Loader2 className="w-3 h-3 animate-spin" />}
+                Send Alerts
+              </button>
+            </div>
+          </div>
+          {staleUsers.length > 0 && (
+            <div className="text-xs text-amber-900">
+              {staleUsers.slice(0, 4).map((u) => (
+                <div key={u.id}>{u.firstName} {u.lastName}: {u.hoursSinceLastSeen}h inactive</div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* SSO panel for BUSINESS_ADMIN */}
       {isBusinessAdmin && currentUser?.tenantId && (


### PR DESCRIPTION
Implements issue #103.\n\n- Adds GET/POST /api/users/stale-alerts for stale salesperson detection and alert dispatch\n- Adds dedupe guard to avoid duplicate daily stale-user alerts\n- Adds Users page stale activity panel with threshold selector and send-alert action\n\nCloses #103