### PR TITLE
feat(users): configurable presence timeout

### DIFF
--- a/apps/api/prisma/migrations/20260402112000_add_tenant_presence_timeout/migration.sql
+++ b/apps/api/prisma/migrations/20260402112000_add_tenant_presence_timeout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tenant" ADD COLUMN "presenceTimeoutMinutes" INTEGER NOT NULL DEFAULT 2;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Tenant {
   address         String?
   logo            String?
   baseCurrency    String   @default("USD")
+  presenceTimeoutMinutes Int @default(2)
   isActive        Boolean  @default(true)
   ssoEnabled      Boolean  @default(false)
   ssoProviders    Json     @default("[]")

--- a/apps/api/src/app/api/tenants/presence-timeout/route.ts
+++ b/apps/api/src/app/api/tenants/presence-timeout/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { hasPermission, isSuperAdmin } from '@/lib/rbac'
+
+const updateSchema = z.object({
+  minutes: z.number().int().min(1).max(30),
+})
+
+function resolveTenantId(user: ReturnType<typeof authenticate>, searchParams: URLSearchParams) {
+  const requestedTenantId = searchParams.get('tenantId') || undefined
+  return isSuperAdmin(user)
+    ? requestedTenantId || user.tenantId || undefined
+    : user.tenantId || undefined
+}
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!hasPermission(user, 'manage:users')) return apiError('Forbidden', 403)
+
+    const { searchParams } = new URL(req.url)
+    const tenantId = resolveTenantId(user, searchParams)
+    if (!tenantId) return apiError('No tenant context for this account. Provide tenantId.', 400)
+
+    const tenant = await prisma.tenant.findUnique({
+      where: { id: tenantId },
+      select: { id: true, presenceTimeoutMinutes: true },
+    })
+    if (!tenant) return apiError('Tenant not found', 404)
+
+    return NextResponse.json({ data: tenant })
+  } catch (err) {
+    if ((err as Error).message === 'Unauthorized') return apiError('Unauthorized', 401)
+    console.error('[TENANT PRESENCE TIMEOUT GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!hasPermission(user, 'manage:users')) return apiError('Forbidden', 403)
+
+    const { searchParams } = new URL(req.url)
+    const tenantId = resolveTenantId(user, searchParams)
+    if (!tenantId) return apiError('No tenant context for this account. Provide tenantId.', 400)
+
+    const body = await req.json()
+    const data = updateSchema.parse(body)
+
+    const tenant = await prisma.tenant.update({
+      where: { id: tenantId },
+      data: { presenceTimeoutMinutes: data.minutes, updatedBy: user.userId },
+      select: { id: true, presenceTimeoutMinutes: true },
+    })
+
+    return NextResponse.json({ data: tenant })
+  } catch (err) {
+    if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if ((err as Error).message === 'Unauthorized') return apiError('Unauthorized', 401)
+    console.error('[TENANT PRESENCE TIMEOUT PATCH]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/client/src/pages/Users.tsx
+++ b/apps/client/src/pages/Users.tsx
@@ -23,11 +23,11 @@ function fullName(u: AuthUser) {
   return `${u.firstName} ${u.lastName}`.trim()
 }
 
-function isCurrentlyOnline(lastSeenAt?: string): boolean {
+function isCurrentlyOnline(lastSeenAt: string | undefined, timeoutMinutes: number): boolean {
   if (!lastSeenAt) return false
   const ts = new Date(lastSeenAt).getTime()
   if (Number.isNaN(ts)) return false
-  return Date.now() - ts <= 2 * 60 * 1000
+  return Date.now() - ts <= timeoutMinutes * 60 * 1000
 }
 
 function SsoPanel({ tenantId }: { tenantId: string }) {
@@ -106,13 +106,15 @@ export default function Users() {
   const [staleLoading, setStaleLoading] = useState(false)
   const [sendingStaleAlerts, setSendingStaleAlerts] = useState(false)
   const [staleUsers, setStaleUsers] = useState<Array<{ id: string; firstName: string; lastName: string; hoursSinceLastSeen: number; thresholdHours: number }>>([])
+  const [presenceTimeoutMinutes, setPresenceTimeoutMinutes] = useState(2)
+  const [savingPresenceTimeout, setSavingPresenceTimeout] = useState(false)
 
   const canManage = currentUser?.role === 'BUSINESS_ADMIN' || currentUser?.role === 'SUPER_ADMIN'
   const isBusinessAdmin = currentUser?.role === 'BUSINESS_ADMIN'
 
   const filteredUsers = users.filter((u) => {
     if (salespersonsOnly && u.role !== 'SALESPERSON') return false
-    if (onlineOnly && !isCurrentlyOnline(u.lastSeenAt)) return false
+    if (onlineOnly && !isCurrentlyOnline(u.lastSeenAt, presenceTimeoutMinutes)) return false
     return true
   })
 
@@ -143,6 +145,29 @@ export default function Users() {
     }
   }
 
+  const loadPresenceTimeout = async () => {
+    if (!canManage) return
+    try {
+      const res = await api.get<{ data: { presenceTimeoutMinutes: number } }>('/tenants/presence-timeout')
+      setPresenceTimeoutMinutes(Math.max(1, Number(res.data.data.presenceTimeoutMinutes || 2)))
+    } catch {
+      setPresenceTimeoutMinutes(2)
+    }
+  }
+
+  const savePresenceTimeout = async (minutes: number) => {
+    setSavingPresenceTimeout(true)
+    try {
+      const res = await api.patch<{ data: { presenceTimeoutMinutes: number } }>('/tenants/presence-timeout', { minutes })
+      setPresenceTimeoutMinutes(Number(res.data.data.presenceTimeoutMinutes || minutes))
+      toast.success('Presence timeout updated')
+    } catch {
+      toast.error('Failed to update presence timeout')
+    } finally {
+      setSavingPresenceTimeout(false)
+    }
+  }
+
   const sendStaleAlerts = async () => {
     setSendingStaleAlerts(true)
     try {
@@ -159,6 +184,10 @@ export default function Users() {
   useEffect(() => {
     void loadStaleUsers()
   }, [staleHours, canManage])
+
+  useEffect(() => {
+    void loadPresenceTimeout()
+  }, [canManage])
 
   const openCreate = () => { setForm(emptyForm); setModal({ open: true, user: null }) }
   const openEdit = (u: AuthUser) => {
@@ -204,6 +233,22 @@ export default function Users() {
           Online now only
         </button>
       </div>
+
+      {canManage && (
+        <div className="rounded-xl border border-gray-100 bg-white p-3 flex flex-wrap items-center gap-2">
+          <p className="text-xs text-gray-600">Presence timeout:</p>
+          {[1, 2, 5].map((m) => (
+            <button
+              key={m}
+              disabled={savingPresenceTimeout}
+              onClick={() => void savePresenceTimeout(m)}
+              className={`badge px-2.5 py-1 text-xs ${presenceTimeoutMinutes === m ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+            >
+              {m} min
+            </button>
+          ))}
+        </div>
+      )}
 
       {canManage && (
         <div className="rounded-xl border border-amber-100 bg-amber-50/60 p-4 space-y-3">
@@ -255,7 +300,7 @@ export default function Users() {
             <tbody>
               {filteredUsers.map((u) => {
                 const sub = subsidiaries.find((s) => s.id === (u as unknown as { subsidiaryId?: string }).subsidiaryId)
-                const online = isCurrentlyOnline(u.lastSeenAt)
+                const online = isCurrentlyOnline(u.lastSeenAt, presenceTimeoutMinutes)
                 return (
                   <tr key={u.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
                     <td className="px-4 py-3">

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -181,6 +181,7 @@ export interface Tenant {
   phone?: string
   isActive: boolean
   baseCurrency: string
+  presenceTimeoutMinutes?: number
   createdAt: string
   subscriptions?: Subscription[]
   _count?: { users: number; subsidiaries: number }


### PR DESCRIPTION
Implements issue #104.\n\n- Adds tenant presence timeout setting with default value\n- Adds GET/PATCH /api/tenants/presence-timeout\n- Updates Users page online logic and filters to use configured timeout\n- Adds admin controls to update timeout (1/2/5 min presets)\n\nCloses #104