### PR TITLE
feat(ops): automate backup verification + restore drills dashboard

### DIFF
--- a/apps/api/prisma/migrations/20260412090000_add_backup_restore_drill_runs/migration.sql
+++ b/apps/api/prisma/migrations/20260412090000_add_backup_restore_drill_runs/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "BackupRestoreDrillRun" (
+    "id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "triggerType" TEXT NOT NULL DEFAULT 'MANUAL',
+    "dbConnectivityOk" BOOLEAN NOT NULL DEFAULT false,
+    "backupVerificationOk" BOOLEAN NOT NULL DEFAULT false,
+    "restoreDrillOk" BOOLEAN NOT NULL DEFAULT false,
+    "backupArtifactPath" TEXT,
+    "backupArtifactMtime" TIMESTAMP(3),
+    "backupArtifactAgeHours" DOUBLE PRECISION,
+    "errorMessage" TEXT,
+    "checkPayload" JSONB,
+    "initiatedByUserId" TEXT,
+    "initiatedByTenantId" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BackupRestoreDrillRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "BackupRestoreDrillRun_startedAt_idx" ON "BackupRestoreDrillRun"("startedAt");
+CREATE INDEX "BackupRestoreDrillRun_status_idx" ON "BackupRestoreDrillRun"("status");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -554,6 +554,29 @@ model Expense {
   @@unique([tenantId, transactionRef])
 }
 
+model BackupRestoreDrillRun {
+  id                    String    @id @default(cuid())
+  status                String
+  triggerType           String    @default("MANUAL")
+  dbConnectivityOk      Boolean   @default(false)
+  backupVerificationOk  Boolean   @default(false)
+  restoreDrillOk        Boolean   @default(false)
+  backupArtifactPath    String?
+  backupArtifactMtime   DateTime?
+  backupArtifactAgeHours Float?
+  errorMessage          String?
+  checkPayload          Json?
+  initiatedByUserId     String?
+  initiatedByTenantId   String?
+  startedAt             DateTime  @default(now())
+  completedAt           DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@index([startedAt])
+  @@index([status])
+}
+
 model SyncTelemetry {
   id            String    @id @default(cuid())
   tenantId      String

--- a/apps/api/src/app/api/ops/backup-drills/route.ts
+++ b/apps/api/src/app/api/ops/backup-drills/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { isSuperAdmin } from '@/lib/rbac'
+
+type BackupRestoreDrillRunDelegate = {
+  findMany(args: unknown): Promise<Array<{
+    id: string
+    status: string
+    triggerType: string
+    dbConnectivityOk: boolean
+    backupVerificationOk: boolean
+    restoreDrillOk: boolean
+    backupArtifactPath: string | null
+    backupArtifactMtime: Date | null
+    backupArtifactAgeHours: number | null
+    errorMessage: string | null
+    checkPayload: unknown
+    initiatedByUserId: string | null
+    initiatedByTenantId: string | null
+    startedAt: Date
+    completedAt: Date | null
+    createdAt: Date
+  }>>
+}
+
+const backupRestoreDrillRun = (prisma as unknown as { backupRestoreDrillRun: BackupRestoreDrillRunDelegate }).backupRestoreDrillRun
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    if (!isSuperAdmin(user)) {
+      return apiError('Forbidden: Only SUPER_ADMIN can access backup drill operations', 403)
+    }
+
+    const limitRaw = Number(req.nextUrl.searchParams.get('limit') || 20)
+    const limit = Number.isFinite(limitRaw) ? Math.min(100, Math.max(1, Math.floor(limitRaw))) : 20
+
+    const rows = await backupRestoreDrillRun.findMany({
+      orderBy: { startedAt: 'desc' },
+      take: limit,
+    })
+
+    const now = Date.now()
+    const thirtyDaysAgo = new Date(now - (30 * 24 * 60 * 60 * 1000))
+    const recent30Days = rows.filter((row) => row.startedAt >= thirtyDaysAgo)
+    const success30Days = recent30Days.filter((row) => row.status === 'SUCCESS').length
+    const successRate30Days = recent30Days.length > 0
+      ? Number(((success30Days / recent30Days.length) * 100).toFixed(1))
+      : 0
+
+    const lastRun = rows[0] || null
+    const lastSuccessfulRun = rows.find((row) => row.status === 'SUCCESS') || null
+
+    const recommendedCadenceHours = Number(process.env.BACKUP_DRILL_RECOMMENDED_CADENCE_HOURS || 168)
+    const nextRecommendedRunAt = lastRun
+      ? new Date(lastRun.startedAt.getTime() + (recommendedCadenceHours * 60 * 60 * 1000))
+      : new Date(now)
+
+    const isOverdue = nextRecommendedRunAt.getTime() < now
+
+    return NextResponse.json({
+      data: {
+        summary: {
+          totalRuns: rows.length,
+          successRate30Days,
+          lastRun,
+          lastSuccessfulRun,
+          nextRecommendedRunAt,
+          recommendedCadenceHours,
+          isOverdue,
+        },
+        rows,
+      },
+    })
+  } catch (err) {
+    console.error('[OPS BACKUP DRILLS GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/api/src/app/api/ops/backup-drills/run/route.ts
+++ b/apps/api/src/app/api/ops/backup-drills/run/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { stat } from 'node:fs/promises'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { isSuperAdmin } from '@/lib/rbac'
+
+type BackupRestoreDrillRunDelegate = {
+  create(args: unknown): Promise<{
+    id: string
+    status: string
+    triggerType: string
+    dbConnectivityOk: boolean
+    backupVerificationOk: boolean
+    restoreDrillOk: boolean
+    backupArtifactPath: string | null
+    backupArtifactMtime: Date | null
+    backupArtifactAgeHours: number | null
+    errorMessage: string | null
+    checkPayload: unknown
+    initiatedByUserId: string | null
+    initiatedByTenantId: string | null
+    startedAt: Date
+    completedAt: Date | null
+    createdAt: Date
+  }>
+}
+
+const backupRestoreDrillRun = (prisma as unknown as { backupRestoreDrillRun: BackupRestoreDrillRunDelegate }).backupRestoreDrillRun
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+function toHours(deltaMs: number): number {
+  return Number((deltaMs / (1000 * 60 * 60)).toFixed(2))
+}
+
+export async function POST(_req: NextRequest) {
+  const startedAt = new Date()
+
+  try {
+    const user = authenticate(_req)
+    if (!isSuperAdmin(user)) {
+      return apiError('Forbidden: Only SUPER_ADMIN can run backup drills', 403)
+    }
+
+    let dbConnectivityOk = false
+    let backupVerificationOk = false
+    let restoreDrillOk = false
+    let backupArtifactMtime: Date | null = null
+    let backupArtifactAgeHours: number | null = null
+    let errorMessage: string | null = null
+
+    const backupArtifactPath = process.env.BACKUP_ARTIFACT_PATH || null
+    const maxBackupAgeHours = Number(process.env.BACKUP_MAX_AGE_HOURS || 48)
+
+    // 1) DB connectivity probe
+    await prisma.$queryRaw`SELECT 1`
+    dbConnectivityOk = true
+
+    // 2) Backup artifact verification (path-based)
+    if (backupArtifactPath) {
+      try {
+        const meta = await stat(backupArtifactPath)
+        backupArtifactMtime = meta.mtime
+        backupArtifactAgeHours = toHours(Date.now() - meta.mtime.getTime())
+        backupVerificationOk = backupArtifactAgeHours <= maxBackupAgeHours
+      } catch (backupErr) {
+        backupVerificationOk = false
+        errorMessage = `Backup artifact check failed: ${(backupErr as Error).message}`
+      }
+    } else {
+      backupVerificationOk = false
+      errorMessage = 'BACKUP_ARTIFACT_PATH is not configured'
+    }
+
+    // 3) Restore drill simulation: create/read temp table in a transaction
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe('CREATE TEMP TABLE IF NOT EXISTS "__backup_restore_drill_tmp" (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)')
+        await tx.$executeRawUnsafe('TRUNCATE "__backup_restore_drill_tmp"')
+        await tx.$executeRawUnsafe("INSERT INTO \"__backup_restore_drill_tmp\" (id, payload) VALUES (1, 'restore-probe')")
+        const result = await tx.$queryRawUnsafe<Array<{ count: number }>>('SELECT COUNT(*)::int AS count FROM "__backup_restore_drill_tmp"')
+        const count = Number(result?.[0]?.count || 0)
+        if (count !== 1) {
+          throw new Error('Restore drill probe returned unexpected row count')
+        }
+      })
+      restoreDrillOk = true
+    } catch (restoreErr) {
+      restoreDrillOk = false
+      errorMessage = errorMessage
+        ? `${errorMessage}; Restore drill failed: ${(restoreErr as Error).message}`
+        : `Restore drill failed: ${(restoreErr as Error).message}`
+    }
+
+    const status = dbConnectivityOk && backupVerificationOk && restoreDrillOk ? 'SUCCESS' : 'FAILED'
+    const completedAt = new Date()
+
+    const row = await backupRestoreDrillRun.create({
+      data: {
+        status,
+        triggerType: 'MANUAL',
+        dbConnectivityOk,
+        backupVerificationOk,
+        restoreDrillOk,
+        backupArtifactPath,
+        backupArtifactMtime,
+        backupArtifactAgeHours,
+        errorMessage,
+        checkPayload: {
+          checks: {
+            dbConnectivityOk,
+            backupVerificationOk,
+            restoreDrillOk,
+          },
+          backup: {
+            backupArtifactPath,
+            maxBackupAgeHours,
+            backupArtifactAgeHours,
+            backupArtifactMtime,
+          },
+        },
+        initiatedByUserId: user.userId,
+        initiatedByTenantId: user.tenantId || null,
+        startedAt,
+        completedAt,
+      },
+    })
+
+    return NextResponse.json({ data: row }, { status: 201 })
+  } catch (err) {
+    console.error('[OPS BACKUP DRILLS RUN POST]', err)
+
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/client/src/components/layout/SuperAdminDashboard.tsx
+++ b/apps/client/src/components/layout/SuperAdminDashboard.tsx
@@ -40,6 +40,29 @@ interface PlatformStats {
   companyGrowth: Array<{ date: string; count: number }>
 }
 
+interface BackupDrillRow {
+  id: string
+  status: 'SUCCESS' | 'FAILED' | string
+  triggerType: string
+  dbConnectivityOk: boolean
+  backupVerificationOk: boolean
+  restoreDrillOk: boolean
+  backupArtifactAgeHours: number | null
+  startedAt: string
+  completedAt: string | null
+  errorMessage: string | null
+}
+
+interface BackupDrillSummary {
+  totalRuns: number
+  successRate30Days: number
+  lastRun: BackupDrillRow | null
+  lastSuccessfulRun: BackupDrillRow | null
+  nextRecommendedRunAt: string
+  recommendedCadenceHours: number
+  isOverdue: boolean
+}
+
 function StatCard({
   label, value, icon: Icon, color, subtext,
 }: {
@@ -65,6 +88,9 @@ const PLAN_COLORS = ['#2563eb', '#16a34a', '#d97706', '#9333ea', '#e11d48', '#08
 
 export default function SuperAdminDashboard() {
   const [stats, setStats] = useState<PlatformStats | null>(null)
+  const [backupSummary, setBackupSummary] = useState<BackupDrillSummary | null>(null)
+  const [backupRows, setBackupRows] = useState<BackupDrillRow[]>([])
+  const [runningBackupDrill, setRunningBackupDrill] = useState(false)
   const [loading, setLoading] = useState(true)
   const [period, setPeriod] = useState<'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly'>('monthly')
 
@@ -85,10 +111,29 @@ export default function SuperAdminDashboard() {
 
   const fetchStats = (selectedPeriod: string) => {
     setLoading(true)
-    api.get(`/reports/platform-stats?period=${selectedPeriod}`)
-      .then((res) => setStats(res.data.data))
+    Promise.all([
+      api.get(`/reports/platform-stats?period=${selectedPeriod}`),
+      api.get('/ops/backup-drills?limit=10'),
+    ])
+      .then(([platformRes, backupRes]) => {
+        setStats(platformRes.data.data)
+        setBackupSummary(backupRes.data?.data?.summary || null)
+        setBackupRows(backupRes.data?.data?.rows || [])
+      })
       .catch(console.error)
       .finally(() => setLoading(false))
+  }
+
+  const runBackupDrill = async () => {
+    setRunningBackupDrill(true)
+    try {
+      await api.post('/ops/backup-drills/run')
+      fetchStats(period)
+    } catch (err) {
+      console.error('Failed to run backup drill', err)
+    } finally {
+      setRunningBackupDrill(false)
+    }
   }
 
   useEffect(() => {
@@ -200,6 +245,74 @@ export default function SuperAdminDashboard() {
           color="bg-danger-50 text-danger-600"
           subtext="Total billing"
         />
+      </div>
+
+      {/* Backup & Restore Drill Operations */}
+      <div className="card p-6 border border-indigo-200 bg-indigo-50/40">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-semibold text-indigo-700 uppercase">Backup & Restore Drills</h3>
+            <p className="text-xs text-indigo-700 mt-1">Automated verification health for backup freshness and restore readiness</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { void runBackupDrill() }}
+            disabled={runningBackupDrill}
+            className={`px-3 py-1 rounded-lg text-sm font-medium ${runningBackupDrill ? 'bg-indigo-300 text-white cursor-not-allowed' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
+          >
+            {runningBackupDrill ? 'Running...' : 'Run Drill'}
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mt-4">
+          <div className="rounded-lg bg-white p-3 border border-indigo-100">
+            <p className="text-xs text-gray-500">Runs Tracked</p>
+            <p className="text-lg font-semibold text-gray-900 mt-1">{backupSummary?.totalRuns ?? 0}</p>
+          </div>
+          <div className="rounded-lg bg-white p-3 border border-indigo-100">
+            <p className="text-xs text-gray-500">30-Day Success Rate</p>
+            <p className="text-lg font-semibold text-gray-900 mt-1">{backupSummary?.successRate30Days ?? 0}%</p>
+          </div>
+          <div className="rounded-lg bg-white p-3 border border-indigo-100">
+            <p className="text-xs text-gray-500">Last Run</p>
+            <p className="text-sm font-semibold text-gray-900 mt-1">{backupSummary?.lastRun ? new Date(backupSummary.lastRun.startedAt).toLocaleString() : 'No run yet'}</p>
+          </div>
+          <div className="rounded-lg bg-white p-3 border border-indigo-100">
+            <p className="text-xs text-gray-500">Next Recommended</p>
+            <p className={`text-sm font-semibold mt-1 ${backupSummary?.isOverdue ? 'text-danger-700' : 'text-gray-900'}`}>
+              {backupSummary?.nextRecommendedRunAt ? new Date(backupSummary.nextRecommendedRunAt).toLocaleString() : 'Run now'}
+            </p>
+          </div>
+        </div>
+
+        {backupRows.length > 0 && (
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-indigo-100">
+                  <th className="text-left py-2 pr-3 font-medium text-gray-500">Started</th>
+                  <th className="text-left py-2 pr-3 font-medium text-gray-500">Status</th>
+                  <th className="text-left py-2 pr-3 font-medium text-gray-500">DB</th>
+                  <th className="text-left py-2 pr-3 font-medium text-gray-500">Backup</th>
+                  <th className="text-left py-2 pr-3 font-medium text-gray-500">Restore</th>
+                  <th className="text-left py-2 font-medium text-gray-500">Backup Age (h)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {backupRows.slice(0, 5).map((row) => (
+                  <tr key={row.id} className="border-b border-indigo-50">
+                    <td className="py-2 pr-3 text-gray-700">{new Date(row.startedAt).toLocaleString()}</td>
+                    <td className={`py-2 pr-3 font-semibold ${row.status === 'SUCCESS' ? 'text-success-700' : 'text-danger-700'}`}>{row.status}</td>
+                    <td className={`py-2 pr-3 ${row.dbConnectivityOk ? 'text-success-700' : 'text-danger-700'}`}>{row.dbConnectivityOk ? 'OK' : 'Fail'}</td>
+                    <td className={`py-2 pr-3 ${row.backupVerificationOk ? 'text-success-700' : 'text-danger-700'}`}>{row.backupVerificationOk ? 'OK' : 'Fail'}</td>
+                    <td className={`py-2 pr-3 ${row.restoreDrillOk ? 'text-success-700' : 'text-danger-700'}`}>{row.restoreDrillOk ? 'OK' : 'Fail'}</td>
+                    <td className="py-2 text-gray-700">{row.backupArtifactAgeHours ?? 'n/a'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       {/* Financial KPIs */}


### PR DESCRIPTION
## Summary\n- add backup/restore drill run persistence model + migration\n- add super-admin ops endpoints to run drills and fetch drill dashboard data\n- surface drill status and manual run action in Platform Dashboard\n\n## Notes\n- backup artifact verification uses BACKUP_ARTIFACT_PATH and BACKUP_MAX_AGE_HOURS\n- restore drill uses a temporary-table transaction probe\n\nFixes #55