### PR TITLE
feat: customer/loyalty module for repeat buyers (Issue #57)

### DIFF
--- a/apps/api/prisma/migrations/20260412130000_add_customer_loyalty_module/migration.sql
+++ b/apps/api/prisma/migrations/20260412130000_add_customer_loyalty_module/migration.sql
@@ -1,0 +1,67 @@
+-- CreateTable: Customer (loyalty / repeat-buyer module)
+CREATE TABLE "Customer" (
+    "id"             TEXT NOT NULL,
+    "tenantId"       TEXT NOT NULL,
+    "name"           TEXT NOT NULL,
+    "phone"          TEXT,
+    "email"          TEXT,
+    "address"        TEXT,
+    "notes"          TEXT,
+    "loyaltyPoints"  INTEGER NOT NULL DEFAULT 0,
+    "totalSpend"     DECIMAL(14,2) NOT NULL DEFAULT 0,
+    "visitCount"     INTEGER NOT NULL DEFAULT 0,
+    "lastVisitedAt"  TIMESTAMP(3),
+    "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"      TIMESTAMP(3) NOT NULL,
+    "createdBy"      TEXT,
+    "updatedBy"      TEXT,
+    "archived"       BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Customer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: LoyaltyLedger
+CREATE TABLE "LoyaltyLedger" (
+    "id"              TEXT NOT NULL,
+    "tenantId"        TEXT NOT NULL,
+    "customerId"      TEXT NOT NULL,
+    "saleId"          TEXT,
+    "type"            TEXT NOT NULL,
+    "points"          INTEGER NOT NULL,
+    "balanceBefore"   INTEGER NOT NULL,
+    "balanceAfter"    INTEGER NOT NULL,
+    "note"            TEXT,
+    "createdByUserId" TEXT,
+    "createdAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LoyaltyLedger_pkey" PRIMARY KEY ("id")
+);
+
+-- Add optional customerId to Sale
+ALTER TABLE "Sale" ADD COLUMN "customerId" TEXT;
+
+-- AddForeignKey: Sale.customerId -> Customer
+ALTER TABLE "Sale" ADD CONSTRAINT "Sale_customerId_fkey"
+    FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey: Customer.tenantId -> Tenant
+ALTER TABLE "Customer" ADD CONSTRAINT "Customer_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: LoyaltyLedger.customerId -> Customer
+ALTER TABLE "LoyaltyLedger" ADD CONSTRAINT "LoyaltyLedger_customerId_fkey"
+    FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex: Customer
+CREATE INDEX "Customer_tenantId_idx" ON "Customer"("tenantId");
+CREATE INDEX "Customer_tenantId_phone_idx" ON "Customer"("tenantId", "phone");
+CREATE INDEX "Customer_tenantId_email_idx" ON "Customer"("tenantId", "email");
+CREATE INDEX "Customer_tenantId_loyaltyPoints_idx" ON "Customer"("tenantId", "loyaltyPoints");
+
+-- CreateIndex: Sale.customerId
+CREATE INDEX "Sale_customerId_idx" ON "Sale"("customerId");
+
+-- CreateIndex: LoyaltyLedger
+CREATE INDEX "LoyaltyLedger_customerId_idx" ON "LoyaltyLedger"("customerId");
+CREATE INDEX "LoyaltyLedger_tenantId_customerId_idx" ON "LoyaltyLedger"("tenantId", "customerId");
+CREATE INDEX "LoyaltyLedger_saleId_idx" ON "LoyaltyLedger"("saleId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -184,6 +184,7 @@ model Tenant {
   currencyRates   CurrencyRate[]
   syncTelemetry   SyncTelemetry[]
   subscriptionTransactions SubscriptionTransaction[]
+  customers        Customer[]
 
   @@index([acquisitionAgentId])
 }
@@ -485,14 +486,18 @@ model Sale {
   updatedBy       String?
   archived        Boolean       @default(false)
 
+  customerId      String?
+
   tenant          Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   subsidiary      Subsidiary    @relation(fields: [subsidiaryId], references: [id])
   user            User          @relation(fields: [userId], references: [id])
+  customer        Customer?     @relation(fields: [customerId], references: [id], onDelete: SetNull)
   items           SaleItem[]
 
   @@index([tenantId])
   @@index([subsidiaryId])
   @@index([userId])
+  @@index([customerId])
   @@index([createdAt])
   @@unique([tenantId, syncRef])
   @@unique([tenantId, transactionRef])
@@ -552,6 +557,58 @@ model Expense {
   @@index([date])
   @@unique([tenantId, syncRef])
   @@unique([tenantId, transactionRef])
+}
+
+// ──────────────────────────────────────────────
+// CUSTOMERS (Loyalty / Repeat Buyer Module)
+// ──────────────────────────────────────────────
+
+model Customer {
+  id              String    @id @default(cuid())
+  tenantId        String
+  name            String
+  phone           String?
+  email           String?
+  address         String?
+  notes           String?
+  loyaltyPoints   Int       @default(0)
+  totalSpend      Decimal   @db.Decimal(14, 2) @default(0)
+  visitCount      Int       @default(0)
+  lastVisitedAt   DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  createdBy       String?
+  updatedBy       String?
+  archived        Boolean   @default(false)
+
+  tenant          Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  sales           Sale[]
+  loyaltyLedger   LoyaltyLedger[]
+
+  @@index([tenantId])
+  @@index([tenantId, phone])
+  @@index([tenantId, email])
+  @@index([tenantId, loyaltyPoints])
+}
+
+model LoyaltyLedger {
+  id              String    @id @default(cuid())
+  tenantId        String
+  customerId      String
+  saleId          String?
+  type            String    // EARN | REDEEM | ADJUST
+  points          Int       // positive = earn, negative = redeem
+  balanceBefore   Int
+  balanceAfter    Int
+  note            String?
+  createdByUserId String?
+  createdAt       DateTime  @default(now())
+
+  customer        Customer  @relation(fields: [customerId], references: [id], onDelete: Cascade)
+
+  @@index([customerId])
+  @@index([tenantId, customerId])
+  @@index([saleId])
 }
 
 model BackupRestoreDrillRun {

--- a/apps/api/src/app/api/customers/[id]/loyalty/route.ts
+++ b/apps/api/src/app/api/customers/[id]/loyalty/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { requirePermission } from '@/lib/rbac'
+
+const adjustSchema = z.object({
+  type: z.enum(['REDEEM', 'ADJUST']),
+  points: z.number().int(),
+  note: z.string().max(255).optional(),
+})
+
+type RouteContext = { params: { id: string } }
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function POST(req: NextRequest, { params }: RouteContext) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'create:sales')
+    const tenantId = user.tenantId
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const customer = await prisma.customer.findFirst({
+      where: { id: params.id, tenantId, archived: false },
+    })
+    if (!customer) return apiError('Customer not found', 404)
+
+    const body = await req.json()
+    const data = adjustSchema.parse(body)
+
+    if (data.type === 'REDEEM' && data.points > 0) {
+      // Redeeming means deducting — points argument must be positive (we flip it)
+      if (customer.loyaltyPoints < data.points) {
+        return apiError('Insufficient loyalty points', 422)
+      }
+    }
+
+    const delta = data.type === 'REDEEM' ? -Math.abs(data.points) : data.points
+    const balanceBefore = customer.loyaltyPoints
+    const balanceAfter = balanceBefore + delta
+
+    if (balanceAfter < 0) return apiError('Resulting balance would be negative', 422)
+
+    const [updated] = await prisma.$transaction([
+      prisma.customer.update({
+        where: { id: params.id },
+        data: { loyaltyPoints: balanceAfter },
+        select: { id: true, loyaltyPoints: true },
+      }),
+      prisma.loyaltyLedger.create({
+        data: {
+          tenantId,
+          customerId: params.id,
+          type: data.type,
+          points: delta,
+          balanceBefore,
+          balanceAfter,
+          note: data.note || null,
+          createdByUserId: user.userId,
+        },
+      }),
+    ])
+
+    return NextResponse.json({ data: updated })
+  } catch (err) {
+    if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[LOYALTY POST]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/api/src/app/api/customers/[id]/route.ts
+++ b/apps/api/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { requirePermission } from '@/lib/rbac'
+
+const updateCustomerSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  phone: z.string().max(40).optional().or(z.literal('')),
+  email: z.string().email().optional().or(z.literal('')),
+  address: z.string().max(255).optional(),
+  notes: z.string().max(500).optional(),
+})
+
+type RouteContext = { params: { id: string } }
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function GET(req: NextRequest, { params }: RouteContext) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'view:sales')
+    const tenantId = user.tenantId
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const customer = await prisma.customer.findFirst({
+      where: { id: params.id, tenantId, archived: false },
+      select: {
+        id: true,
+        name: true,
+        phone: true,
+        email: true,
+        address: true,
+        notes: true,
+        loyaltyPoints: true,
+        totalSpend: true,
+        visitCount: true,
+        lastVisitedAt: true,
+        createdAt: true,
+      },
+    })
+    if (!customer) return apiError('Customer not found', 404)
+
+    // Purchase history (last 20 sales)
+    const sales = await prisma.sale.findMany({
+      where: { customerId: params.id, tenantId, archived: false },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        receiptNumber: true,
+        totalAmount: true,
+        currency: true,
+        paymentMethod: true,
+        createdAt: true,
+        items: {
+          select: {
+            quantity: true,
+            unitPrice: true,
+            product: { select: { name: true } },
+          },
+        },
+      },
+    })
+
+    // Loyalty ledger (last 30 entries)
+    const ledger = await prisma.loyaltyLedger.findMany({
+      where: { customerId: params.id },
+      orderBy: { createdAt: 'desc' },
+      take: 30,
+      select: {
+        id: true,
+        type: true,
+        points: true,
+        balanceBefore: true,
+        balanceAfter: true,
+        note: true,
+        saleId: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json({ data: { ...customer, purchaseHistory: sales, loyaltyLedger: ledger } })
+  } catch (err) {
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[CUSTOMER GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'create:sales')
+    const tenantId = user.tenantId
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const existing = await prisma.customer.findFirst({ where: { id: params.id, tenantId } })
+    if (!existing) return apiError('Customer not found', 404)
+
+    const body = await req.json()
+    const patch = updateCustomerSchema.parse(body)
+
+    const updated = await prisma.customer.update({
+      where: { id: params.id },
+      data: {
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.phone !== undefined ? { phone: patch.phone || null } : {}),
+        ...(patch.email !== undefined ? { email: patch.email || null } : {}),
+        ...(patch.address !== undefined ? { address: patch.address || null } : {}),
+        ...(patch.notes !== undefined ? { notes: patch.notes || null } : {}),
+        updatedBy: user.userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        phone: true,
+        email: true,
+        address: true,
+        loyaltyPoints: true,
+        totalSpend: true,
+        visitCount: true,
+        lastVisitedAt: true,
+        updatedAt: true,
+      },
+    })
+
+    return NextResponse.json({ data: updated })
+  } catch (err) {
+    if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[CUSTOMER PATCH]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'create:sales')
+    const tenantId = user.tenantId
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const existing = await prisma.customer.findFirst({ where: { id: params.id, tenantId } })
+    if (!existing) return apiError('Customer not found', 404)
+
+    // Soft delete
+    await prisma.customer.update({
+      where: { id: params.id },
+      data: { archived: true, updatedBy: user.userId },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[CUSTOMER DELETE]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/api/src/app/api/customers/route.ts
+++ b/apps/api/src/app/api/customers/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { authenticate, apiError, handleOptions } from '@/lib/auth'
+import { requirePermission, isSuperAdmin } from '@/lib/rbac'
+
+const createCustomerSchema = z.object({
+  name: z.string().min(1).max(120),
+  phone: z.string().max(40).optional(),
+  email: z.string().email().optional().or(z.literal('')),
+  address: z.string().max(255).optional(),
+  notes: z.string().max(500).optional(),
+})
+
+export async function OPTIONS() {
+  return handleOptions()
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'view:sales')
+
+    const { searchParams } = new URL(req.url)
+    const tenantId = isSuperAdmin(user)
+      ? searchParams.get('tenantId') || user.tenantId!
+      : user.tenantId!
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const q = searchParams.get('q')?.trim() || ''
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1'))
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '50')))
+
+    const where = {
+      tenantId,
+      archived: false,
+      ...(q
+        ? {
+            OR: [
+              { name: { contains: q, mode: 'insensitive' as const } },
+              { phone: { contains: q, mode: 'insensitive' as const } },
+              { email: { contains: q, mode: 'insensitive' as const } },
+            ],
+          }
+        : {}),
+    }
+
+    const [data, total] = await Promise.all([
+      prisma.customer.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          phone: true,
+          email: true,
+          address: true,
+          loyaltyPoints: true,
+          totalSpend: true,
+          visitCount: true,
+          lastVisitedAt: true,
+          createdAt: true,
+        },
+      }),
+      prisma.customer.count({ where }),
+    ])
+
+    return NextResponse.json({ data, total, page, limit })
+  } catch (err) {
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[CUSTOMERS GET]', err)
+    return apiError('Internal server error', 500)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = authenticate(req)
+    requirePermission(user, 'create:sales')
+    const tenantId = user.tenantId
+    if (!tenantId) return apiError('No tenant context', 400)
+
+    const body = await req.json()
+    const data = createCustomerSchema.parse(body)
+
+    const customer = await prisma.customer.create({
+      data: {
+        tenantId,
+        name: data.name,
+        phone: data.phone || null,
+        email: data.email || null,
+        address: data.address || null,
+        notes: data.notes || null,
+        createdBy: user.userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        phone: true,
+        email: true,
+        address: true,
+        loyaltyPoints: true,
+        totalSpend: true,
+        visitCount: true,
+        lastVisitedAt: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json({ data: customer }, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
+    console.error('[CUSTOMERS POST]', err)
+    return apiError('Internal server error', 500)
+  }
+}

--- a/apps/api/src/app/api/sales/route.ts
+++ b/apps/api/src/app/api/sales/route.ts
@@ -25,6 +25,7 @@ const createSaleSchema = z.object({
   syncRef: z.string().min(6).max(120).optional(),
   transactionRef: z.string().min(6).max(180).optional(),
   notes: z.string().optional(),
+  customerId: z.string().optional(),
 })
 
 export async function OPTIONS() {
@@ -191,7 +192,16 @@ export async function POST(req: NextRequest) {
         }
       }
 
-      return tx.sale.create({
+      // Validate customerId belongs to this tenant
+      let resolvedCustomerId: string | undefined = undefined
+      if (data.customerId) {
+        const cust = await tx.customer.findFirst({
+          where: { id: data.customerId, tenantId: user.tenantId!, archived: false },
+        })
+        if (cust) resolvedCustomerId = cust.id
+      }
+
+      const createdSale = await tx.sale.create({
         data: {
           tenantId: user.tenantId!,
           subsidiaryId: data.subsidiaryId,
@@ -207,6 +217,7 @@ export async function POST(req: NextRequest) {
           receiptNumber,
           notes: data.notes,
           createdBy: user.userId,
+          customerId: resolvedCustomerId,
           items: {
             create: subtotals.map((item) => ({
               productId: item.productId,
@@ -225,6 +236,53 @@ export async function POST(req: NextRequest) {
           user: { select: { firstName: true, lastName: true } },
         },
       })
+
+      // Loyalty accrual: 1 point per whole unit of the base-currency amount
+      if (resolvedCustomerId) {
+        const earnedPoints = Math.floor(totalAmount)
+        const customer = await tx.customer.findFirst({
+          where: { id: resolvedCustomerId },
+          select: { loyaltyPoints: true },
+        })
+        if (customer && earnedPoints > 0) {
+          const balanceBefore = customer.loyaltyPoints
+          const balanceAfter = balanceBefore + earnedPoints
+          await tx.customer.update({
+            where: { id: resolvedCustomerId },
+            data: {
+              loyaltyPoints: balanceAfter,
+              totalSpend: { increment: totalAmount },
+              visitCount: { increment: 1 },
+              lastVisitedAt: new Date(),
+            },
+          })
+          await tx.loyaltyLedger.create({
+            data: {
+              tenantId: user.tenantId!,
+              customerId: resolvedCustomerId,
+              saleId: createdSale.id,
+              type: 'EARN',
+              points: earnedPoints,
+              balanceBefore,
+              balanceAfter,
+              note: `Earned from sale ${receiptNumber}`,
+              createdByUserId: user.userId,
+            },
+          })
+        } else if (customer) {
+          // Zero-value sale: still count the visit
+          await tx.customer.update({
+            where: { id: resolvedCustomerId },
+            data: {
+              totalSpend: { increment: totalAmount },
+              visitCount: { increment: 1 },
+              lastVisitedAt: new Date(),
+            },
+          })
+        }
+      }
+
+      return createdSale
     })
 
     // Trigger low stock checks asynchronously

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -15,6 +15,7 @@ const SsoCallback = lazy(() => import('@/pages/SsoCallback'))
 const Dashboard = lazy(() => import('@/pages/Dashboard'))
 const Products = lazy(() => import('@/pages/Products'))
 const SalesPage = lazy(() => import('@/pages/Sales'))
+const CustomersPage = lazy(() => import('@/pages/Customers'))
 const Expenses = lazy(() => import('@/pages/Expenses'))
 const Reports = lazy(() => import('@/pages/Reports'))
 const Subsidiaries = lazy(() => import('@/pages/Subsidiaries'))
@@ -164,6 +165,7 @@ export default function App() {
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="products" element={<Products />} />
             <Route path="sales" element={<SalesPage />} />
+            <Route path="customers" element={<CustomersPage />} />
             <Route path="expenses" element={<Expenses />} />
             <Route path="reports" element={<Reports />} />
             <Route path="subsidiaries" element={<Subsidiaries />} />
@@ -225,6 +227,7 @@ export default function App() {
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="products" element={<Products />} />
             <Route path="sales" element={<SalesPage />} />
+            <Route path="customers" element={<CustomersPage />} />
             <Route path="expenses" element={<Expenses />} />
             <Route path="reports" element={<Reports />} />
             <Route path="subsidiaries" element={<Subsidiaries />} />

--- a/apps/client/src/components/customers/CustomerSelector.tsx
+++ b/apps/client/src/components/customers/CustomerSelector.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef, useCallback, type MouseEvent } from 'react'
+import { Search, X, UserPlus, Star, ChevronDown } from 'lucide-react'
+import api from '@/lib/api'
+import type { Customer } from '@/types'
+import toast from 'react-hot-toast'
+
+interface Props {
+  selectedCustomer: Customer | null
+  onSelect: (customer: Customer | null) => void
+}
+
+export default function CustomerSelector({ selectedCustomer, onSelect }: Props) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Customer[]>([])
+  const [searching, setSearching] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newPhone, setNewPhone] = useState('')
+  const [creating, setCreating] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const search = useCallback(async (q: string) => {
+    setSearching(true)
+    try {
+      const res = await api.get<{ data: Customer[] }>('/customers', { params: { q, limit: 20 } })
+      setResults(res.data.data || [])
+    } catch {
+      setResults([])
+    } finally {
+      setSearching(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => search(query), 300)
+    return () => clearTimeout(debounceRef.current)
+  }, [query, open, search])
+
+  // Initial load when dropdown opens
+  useEffect(() => {
+    if (open && results.length === 0 && !query) {
+      search('')
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false)
+        setShowCreate(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      const res = await api.post<{ data: Customer }>('/customers', {
+        name: newName.trim(),
+        phone: newPhone.trim() || undefined,
+      })
+      toast.success('Customer created')
+      onSelect(res.data.data)
+      setOpen(false)
+      setShowCreate(false)
+      setNewName('')
+      setNewPhone('')
+    } catch {
+      toast.error('Failed to create customer')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleSelect = (c: Customer) => {
+    onSelect(c)
+    setOpen(false)
+    setQuery('')
+  }
+
+  const handleClear = (e: MouseEvent) => {
+    e.stopPropagation()
+    onSelect(null)
+  }
+
+  return (
+    <div className="relative" ref={panelRef}>
+      {/* Trigger */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm hover:border-blue-400 transition-colors"
+      >
+        <Star className="w-4 h-4 text-yellow-400 flex-shrink-0" />
+        {selectedCustomer ? (
+          <span className="flex-1 text-left text-gray-900 dark:text-gray-100 truncate">
+            {selectedCustomer.name}
+            <span className="ml-2 text-xs text-yellow-600 dark:text-yellow-400 font-semibold">
+              {selectedCustomer.loyaltyPoints} pts
+            </span>
+          </span>
+        ) : (
+          <span className="flex-1 text-left text-gray-400">Attach customer (optional)</span>
+        )}
+        {selectedCustomer ? (
+          <X className="w-4 h-4 text-gray-400 hover:text-red-500" onClick={handleClear} />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-gray-400" />
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute z-50 mt-1 left-0 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg">
+          <div className="p-2">
+            <div className="flex items-center gap-1 px-2 py-1 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+              <Search className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+              <input
+                autoFocus
+                className="flex-1 bg-transparent text-sm outline-none placeholder-gray-400 dark:text-gray-100"
+                placeholder="Search by name or phone..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <ul className="max-h-52 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
+            {searching ? (
+              <li className="px-4 py-3 text-xs text-gray-400 text-center">Searching…</li>
+            ) : results.length === 0 ? (
+              <li className="px-4 py-3 text-xs text-gray-400 text-center">No customers found</li>
+            ) : (
+              results.map((c) => (
+                <li
+                  key={c.id}
+                  className="px-4 py-2.5 cursor-pointer hover:bg-blue-50 dark:hover:bg-blue-900/30 flex items-center justify-between"
+                  onClick={() => handleSelect(c)}
+                >
+                  <div>
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{c.name}</div>
+                    {c.phone && <div className="text-xs text-gray-400">{c.phone}</div>}
+                  </div>
+                  <span className="text-xs font-semibold text-yellow-600 dark:text-yellow-400 whitespace-nowrap ml-3">
+                    {c.loyaltyPoints} pts
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+
+          {!showCreate ? (
+            <div className="p-2 border-t border-gray-100 dark:border-gray-700">
+              <button
+                type="button"
+                onClick={() => setShowCreate(true)}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors"
+              >
+                <UserPlus className="w-4 h-4" />
+                New customer
+              </button>
+            </div>
+          ) : (
+            <div className="p-3 border-t border-gray-100 dark:border-gray-700 space-y-2">
+              <input
+                autoFocus
+                className="w-full px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-sm outline-none focus:border-blue-400"
+                placeholder="Full name *"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+              <input
+                className="w-full px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-sm outline-none focus:border-blue-400"
+                placeholder="Phone (optional)"
+                value={newPhone}
+                onChange={(e) => setNewPhone(e.target.value)}
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowCreate(false)}
+                  className="flex-1 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-900"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={!newName.trim() || creating}
+                  onClick={handleCreate}
+                  className="flex-1 px-3 py-1.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {creating ? 'Saving…' : 'Create'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/client/src/components/layout/Sidebar.tsx
+++ b/apps/client/src/components/layout/Sidebar.tsx
@@ -39,6 +39,7 @@ const navSections: NavSection[] = [
     items: [
       { label: 'Products', href: '/products', icon: Package, roles: ['BUSINESS_ADMIN', 'SALESPERSON'] },
       { label: 'Sales / POS', href: '/sales', icon: ShoppingCart, roles: ['BUSINESS_ADMIN', 'SALESPERSON'] },
+      { label: 'Customers', href: '/customers', icon: Users, roles: ['BUSINESS_ADMIN', 'SALESPERSON'] },
       { label: 'Expenses', href: '/expenses', icon: Receipt, roles: ['SUPER_ADMIN', 'BUSINESS_ADMIN', 'SALESPERSON'] },
     ],
   },

--- a/apps/client/src/pages/Customers.tsx
+++ b/apps/client/src/pages/Customers.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useState } from 'react'
+import { Users, Search, Star, History, Gift, Plus, PencilLine, Trash2 } from 'lucide-react'
+import api from '@/lib/api'
+import toast from 'react-hot-toast'
+import type { Customer, LoyaltyLedgerEntry } from '@/types'
+
+interface CustomerDetail extends Customer {
+  purchaseHistory: Array<{
+    id: string
+    receiptNumber: string
+    totalAmount: number
+    currency: string
+    paymentMethod: string
+    createdAt: string
+    items: Array<{ quantity: number; unitPrice: number; product: { name: string } }>
+  }>
+  loyaltyLedger: LoyaltyLedgerEntry[]
+}
+
+export default function CustomersPage() {
+  const [items, setItems] = useState<Customer[]>([])
+  const [selected, setSelected] = useState<CustomerDetail | null>(null)
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [editing, setEditing] = useState<Customer | null>(null)
+  const [form, setForm] = useState({ name: '', phone: '', email: '', address: '', notes: '' })
+  const [saving, setSaving] = useState(false)
+  const [adjustPoints, setAdjustPoints] = useState('')
+  const [adjustNote, setAdjustNote] = useState('')
+
+  const loadCustomers = async (q = '') => {
+    setLoading(true)
+    try {
+      const res = await api.get('/customers', { params: { q, limit: 100 } })
+      setItems(res.data.data || [])
+    } catch {
+      toast.error('Failed to load customers')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadCustomerDetail = async (id: string) => {
+    try {
+      const res = await api.get(`/customers/${id}`)
+      setSelected(res.data.data)
+    } catch {
+      toast.error('Failed to load customer details')
+    }
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => loadCustomers(search), 250)
+    return () => clearTimeout(t)
+  }, [search])
+
+  useEffect(() => {
+    void loadCustomers('')
+  }, [])
+
+  const resetForm = () => {
+    setForm({ name: '', phone: '', email: '', address: '', notes: '' })
+    setEditing(null)
+    setShowCreate(false)
+  }
+
+  const submitForm = async () => {
+    if (!form.name.trim()) {
+      toast.error('Customer name is required')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editing) {
+        await api.patch(`/customers/${editing.id}`, form)
+        toast.success('Customer updated')
+        await loadCustomers(search)
+        await loadCustomerDetail(editing.id)
+      } else {
+        const res = await api.post('/customers', form)
+        toast.success('Customer created')
+        await loadCustomers(search)
+        await loadCustomerDetail(res.data.data.id)
+      }
+      resetForm()
+    } catch {
+      toast.error('Failed to save customer')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const startEdit = (customer: Customer) => {
+    setEditing(customer)
+    setShowCreate(true)
+    setForm({
+      name: customer.name || '',
+      phone: customer.phone || '',
+      email: customer.email || '',
+      address: customer.address || '',
+      notes: '',
+    })
+  }
+
+  const removeCustomer = async (customer: Customer) => {
+    if (!confirm(`Archive ${customer.name}?`)) return
+    try {
+      await api.delete(`/customers/${customer.id}`)
+      toast.success('Customer archived')
+      if (selected?.id === customer.id) setSelected(null)
+      await loadCustomers(search)
+    } catch {
+      toast.error('Failed to archive customer')
+    }
+  }
+
+  const applyAdjustment = async (type: 'ADJUST' | 'REDEEM') => {
+    if (!selected) return
+    const value = parseInt(adjustPoints || '0')
+    if (!value) {
+      toast.error('Enter points value')
+      return
+    }
+    try {
+      await api.post(`/customers/${selected.id}/loyalty`, {
+        type,
+        points: value,
+        note: adjustNote || undefined,
+      })
+      toast.success(type === 'REDEEM' ? 'Points redeemed' : 'Points adjusted')
+      setAdjustPoints('')
+      setAdjustNote('')
+      await loadCustomers(search)
+      await loadCustomerDetail(selected.id)
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error || 'Loyalty update failed')
+    }
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
+      <section className="card p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">Customers & Loyalty</h1>
+            <p className="text-sm text-gray-500">Repeat buyers, purchase history, and point balances.</p>
+          </div>
+          <button className="btn-primary px-3 py-2" onClick={() => { resetForm(); setShowCreate(true) }}>
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            className="input pl-9"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search customer by name, phone, email"
+          />
+        </div>
+
+        {showCreate && (
+          <div className="rounded-xl border border-gray-200 p-3 space-y-2 bg-gray-50">
+            <input className="input" placeholder="Name *" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} />
+            <input className="input" placeholder="Phone" value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} />
+            <input className="input" placeholder="Email" value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} />
+            <input className="input" placeholder="Address" value={form.address} onChange={(e) => setForm((f) => ({ ...f, address: e.target.value }))} />
+            <textarea className="input min-h-[72px]" placeholder="Notes" value={form.notes} onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} />
+            <div className="flex gap-2">
+              <button className="btn-secondary flex-1" onClick={resetForm}>Cancel</button>
+              <button className="btn-primary flex-1" onClick={submitForm} disabled={saving}>{saving ? 'Saving...' : editing ? 'Update' : 'Create'}</button>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2 max-h-[68vh] overflow-y-auto pr-1">
+          {loading ? (
+            <div className="text-sm text-gray-400 py-6 text-center">Loading customers...</div>
+          ) : items.length === 0 ? (
+            <div className="py-10 text-center text-gray-400">
+              <Users className="w-10 h-10 mx-auto mb-2 opacity-40" />
+              <p className="text-sm">No customers found</p>
+            </div>
+          ) : (
+            items.map((customer) => (
+              <button
+                key={customer.id}
+                className={`w-full text-left rounded-xl border p-3 transition-colors ${selected?.id === customer.id ? 'border-blue-300 bg-blue-50' : 'border-gray-200 bg-white hover:border-gray-300'}`}
+                onClick={() => loadCustomerDetail(customer.id)}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <div className="font-semibold text-gray-900">{customer.name}</div>
+                    <div className="text-xs text-gray-400">{customer.phone || customer.email || 'No contact info'}</div>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button type="button" className="p-1 rounded hover:bg-white" onClick={(e) => { e.stopPropagation(); startEdit(customer) }}>
+                      <PencilLine className="w-3.5 h-3.5 text-gray-400" />
+                    </button>
+                    <button type="button" className="p-1 rounded hover:bg-white" onClick={(e) => { e.stopPropagation(); void removeCustomer(customer) }}>
+                      <Trash2 className="w-3.5 h-3.5 text-red-400" />
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                  <div className="rounded-lg bg-amber-50 px-2 py-2">
+                    <div className="text-gray-400">Points</div>
+                    <div className="font-semibold text-amber-700">{customer.loyaltyPoints}</div>
+                  </div>
+                  <div className="rounded-lg bg-gray-50 px-2 py-2">
+                    <div className="text-gray-400">Visits</div>
+                    <div className="font-semibold text-gray-900">{customer.visitCount}</div>
+                  </div>
+                  <div className="rounded-lg bg-gray-50 px-2 py-2">
+                    <div className="text-gray-400">Spend</div>
+                    <div className="font-semibold text-gray-900">{Number(customer.totalSpend || 0).toFixed(0)}</div>
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="card p-5 min-h-[60vh]">
+        {!selected ? (
+          <div className="h-full flex items-center justify-center text-center text-gray-400">
+            <div>
+              <Users className="w-12 h-12 mx-auto mb-3 opacity-40" />
+              <p className="text-sm">Select a customer to view purchase history and loyalty ledger</p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">{selected.name}</h2>
+                <p className="text-sm text-gray-500">{selected.phone || selected.email || 'No contact info'}</p>
+                {selected.address && <p className="text-sm text-gray-400 mt-1">{selected.address}</p>}
+              </div>
+              <div className="grid grid-cols-3 gap-2 min-w-[280px]">
+                <div className="rounded-xl bg-amber-50 p-3 text-center">
+                  <div className="text-xs text-gray-400">Loyalty Points</div>
+                  <div className="text-lg font-bold text-amber-700">{selected.loyaltyPoints}</div>
+                </div>
+                <div className="rounded-xl bg-gray-50 p-3 text-center">
+                  <div className="text-xs text-gray-400">Visits</div>
+                  <div className="text-lg font-bold text-gray-900">{selected.visitCount}</div>
+                </div>
+                <div className="rounded-xl bg-gray-50 p-3 text-center">
+                  <div className="text-xs text-gray-400">Total Spend</div>
+                  <div className="text-lg font-bold text-gray-900">{Number(selected.totalSpend || 0).toFixed(2)}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 p-4 bg-gradient-to-r from-amber-50 to-orange-50">
+              <div className="flex items-center gap-2 mb-3">
+                <Gift className="w-4 h-4 text-amber-600" />
+                <h3 className="font-semibold text-gray-900">Targeted Promotions / Loyalty Actions</h3>
+              </div>
+              <div className="grid md:grid-cols-[120px_1fr_auto_auto] gap-2 items-center">
+                <input className="input" type="number" value={adjustPoints} onChange={(e) => setAdjustPoints(e.target.value)} placeholder="Points" />
+                <input className="input" value={adjustNote} onChange={(e) => setAdjustNote(e.target.value)} placeholder="Reason or promo note" />
+                <button className="btn-secondary" onClick={() => applyAdjustment('ADJUST')}>Adjust</button>
+                <button className="btn-primary" onClick={() => applyAdjustment('REDEEM')}>Redeem</button>
+              </div>
+              <p className="text-xs text-gray-500 mt-2">Use this for targeted promotions, manual corrections, or point redemption at checkout support desk.</p>
+            </div>
+
+            <div className="grid lg:grid-cols-2 gap-6">
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <History className="w-4 h-4 text-blue-600" />
+                  <h3 className="font-semibold text-gray-900">Purchase History</h3>
+                </div>
+                <div className="space-y-3 max-h-[420px] overflow-y-auto pr-1">
+                  {selected.purchaseHistory.length === 0 ? (
+                    <div className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-400">No purchases yet</div>
+                  ) : selected.purchaseHistory.map((sale) => (
+                    <div key={sale.id} className="rounded-xl border border-gray-200 p-3 bg-white">
+                      <div className="flex items-center justify-between gap-2">
+                        <div>
+                          <div className="font-medium text-gray-900">{sale.receiptNumber}</div>
+                          <div className="text-xs text-gray-400">{new Date(sale.createdAt).toLocaleString()}</div>
+                        </div>
+                        <div className="text-sm font-semibold text-gray-900">{sale.currency} {Number(sale.totalAmount).toFixed(2)}</div>
+                      </div>
+                      <div className="mt-2 text-xs text-gray-500">
+                        {sale.items.slice(0, 3).map((item) => `${Number(item.quantity)}x ${item.product.name}`).join(', ')}
+                        {sale.items.length > 3 ? ` +${sale.items.length - 3} more` : ''}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <Star className="w-4 h-4 text-amber-600" />
+                  <h3 className="font-semibold text-gray-900">Loyalty Ledger</h3>
+                </div>
+                <div className="space-y-3 max-h-[420px] overflow-y-auto pr-1">
+                  {selected.loyaltyLedger.length === 0 ? (
+                    <div className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-400">No loyalty activity yet</div>
+                  ) : selected.loyaltyLedger.map((entry) => (
+                    <div key={entry.id} className="rounded-xl border border-gray-200 p-3 bg-white">
+                      <div className="flex items-center justify-between gap-2">
+                        <div>
+                          <div className="font-medium text-gray-900">{entry.type}</div>
+                          <div className="text-xs text-gray-400">{new Date(entry.createdAt).toLocaleString()}</div>
+                        </div>
+                        <div className={`text-sm font-semibold ${entry.points >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                          {entry.points >= 0 ? '+' : ''}{entry.points} pts
+                        </div>
+                      </div>
+                      <div className="mt-2 flex items-center justify-between text-xs text-gray-500">
+                        <span>{entry.note || 'No note'}</span>
+                        <span>{entry.balanceBefore} → {entry.balanceAfter}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/client/src/pages/Sales.tsx
+++ b/apps/client/src/pages/Sales.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { Search, Barcode, Trash2, Minus, Plus, ShoppingCart, WifiOff, History, ShoppingBag, AlertTriangle } from 'lucide-react'
 import { useCartStore } from '@/store/cart.store'
-import type { Product, Sale, SaleCheckoutPayload, Subsidiary } from '@/types'
+import type { Product, Sale, SaleCheckoutPayload, Subsidiary, Customer } from '@/types'
 import api from '@/lib/api'
 import toast from 'react-hot-toast'
 import {
@@ -16,6 +16,7 @@ import { useAuthStore } from '@/store/auth.store'
 import Receipt from '@/components/sales/Receipt'
 import Pagination from '@/components/Pagination'
 import { makeCurrencyFormatter, getCurrencySymbol, SUPPORTED_CURRENCIES } from '@/lib/currency'
+import CustomerSelector from '@/components/customers/CustomerSelector'
 
 let _audioCtx: AudioContext | null = null
 function getAudioContext(): AudioContext | null {
@@ -68,6 +69,7 @@ export default function SalesPage() {
   const [rateError, setRateError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [completedSale, setCompletedSale] = useState<{ id: string; receiptNumber: string; offline?: boolean } | null>(null)
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null)
   const [scanState, setScanState] = useState<'idle' | 'success' | 'error'>('idle')
   const barcodeBuffer = useRef('')
   const barcodeTimer = useRef<ReturnType<typeof setTimeout>>()
@@ -398,6 +400,7 @@ export default function SalesPage() {
         amountPaid,
         currency: saleCurrency,
         fxRate: saleFxRate,
+        customerId: selectedCustomer?.id,
         items: cart.items.map((i) => ({
           productId: i.product.id,
           quantity: i.quantity,
@@ -413,6 +416,7 @@ export default function SalesPage() {
         cart.clearCart()
         setDiscount(0)
         setAmountPaid(0)
+        setSelectedCustomer(null)
         setCompletedSale({ id: localId, receiptNumber: `OFFLINE-${Date.now()}`, offline: true })
         toast.success('Sale saved offline — will sync when back online')
         return
@@ -423,6 +427,7 @@ export default function SalesPage() {
       cart.clearCart()
       setDiscount(0)
       setAmountPaid(0)
+      setSelectedCustomer(null)
       toast.success('Sale completed!')
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error || 'Checkout failed'
@@ -696,6 +701,33 @@ export default function SalesPage() {
 
           {/* Totals & Checkout */}
           <div className="p-4 border-t border-gray-100 space-y-3">
+            <div className="space-y-2 rounded-xl border border-amber-200 bg-amber-50/70 p-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-wide text-amber-800">Repeat Buyer</span>
+                {selectedCustomer && (
+                  <span className="text-xs font-semibold text-amber-700">
+                    Earns {Math.floor(Math.max(0, total))} pts
+                  </span>
+                )}
+              </div>
+              <CustomerSelector selectedCustomer={selectedCustomer} onSelect={setSelectedCustomer} />
+              {selectedCustomer && (
+                <div className="grid grid-cols-3 gap-2 text-xs">
+                  <div className="rounded-lg bg-white/80 px-2 py-2 text-center">
+                    <div className="text-gray-400">Points</div>
+                    <div className="font-semibold text-amber-700">{selectedCustomer.loyaltyPoints}</div>
+                  </div>
+                  <div className="rounded-lg bg-white/80 px-2 py-2 text-center">
+                    <div className="text-gray-400">Visits</div>
+                    <div className="font-semibold text-gray-900">{selectedCustomer.visitCount}</div>
+                  </div>
+                  <div className="rounded-lg bg-white/80 px-2 py-2 text-center">
+                    <div className="text-gray-400">Spend</div>
+                    <div className="font-semibold text-gray-900">{fmt(Number(selectedCustomer.totalSpend || 0))}</div>
+                  </div>
+                </div>
+              )}
+            </div>
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-500">Subtotal</span>
               <span>

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -65,6 +65,7 @@ export interface Sale {
   tenantId: string
   subsidiaryId: string
   userId: string
+  customerId?: string | null
   totalAmount: number
   discount: number
   amountPaid: number
@@ -77,6 +78,7 @@ export interface Sale {
   items: SaleItem[]
   user?: { firstName: string; lastName: string }
   subsidiary?: { name: string }
+  customer?: { id: string; name: string; loyaltyPoints: number } | null
 }
 
 // Cart item (frontend only)
@@ -98,6 +100,7 @@ export interface SaleCheckoutPayload {
   syncRef?: string
   transactionRef?: string
   notes?: string
+  customerId?: string
   items: {
     productId: string
     quantity: number
@@ -202,6 +205,33 @@ export interface TrustedCustomer {
   isActive: boolean
   createdAt: string
   updatedAt: string
+}
+
+// Loyalty / Repeat Buyer
+export interface Customer {
+  id: string
+  tenantId: string
+  name: string
+  phone?: string | null
+  email?: string | null
+  address?: string | null
+  notes?: string | null
+  loyaltyPoints: number
+  totalSpend: number
+  visitCount: number
+  lastVisitedAt?: string | null
+  createdAt: string
+}
+
+export interface LoyaltyLedgerEntry {
+  id: string
+  type: 'EARN' | 'REDEEM' | 'ADJUST'
+  points: number
+  balanceBefore: number
+  balanceAfter: number
+  note?: string | null
+  saleId?: string | null
+  createdAt: string
 }
 
 // ── Plans & Subscriptions ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- adds tenant-scoped customer profiles and loyalty ledger models\n- links sales to optional customer and accrues loyalty points during POS checkout\n- adds customer APIs (list/create, detail/history, loyalty adjustments)\n- adds Customers page and POS customer selector for repeat-buyer workflows\n\n## Validation\n- checked errors on touched API/client/schema files: no diagnostics\n\nCloses #57