### PR TITLE
fix: customer selector MouseEvent typing regression

### DIFF
--- a/apps/client/src/components/customers/CustomerSelector.tsx
+++ b/apps/client/src/components/customers/CustomerSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, type MouseEvent } from 'react'
+import { useState, useEffect, useRef, useCallback, type MouseEvent as ReactMouseEvent } from 'react'
 import { Search, X, UserPlus, Star, ChevronDown } from 'lucide-react'
 import api from '@/lib/api'
 import type { Customer } from '@/types'
@@ -49,7 +49,7 @@ export default function CustomerSelector({ selectedCustomer, onSelect }: Props) 
 
   // Close on outside click
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const handler = (e: globalThis.MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setOpen(false)
         setShowCreate(false)
@@ -86,7 +86,7 @@ export default function CustomerSelector({ selectedCustomer, onSelect }: Props) 
     setQuery('')
   }
 
-  const handleClear = (e: MouseEvent) => {
+  const handleClear = (e: ReactMouseEvent) => {
     e.stopPropagation()
     onSelect(null)
   }


### PR DESCRIPTION
## Finding\nPR #159 introduced a TypeScript type mismatch in the customer selector document mousedown handler (React MouseEvent vs DOM MouseEvent), causing 
pm run build -w stockpilot-client to fail.\n\n## Fix\n- use globalThis.MouseEvent for document listener callback\n- keep React click handler typed as ReactMouseEvent\n\n## Validation\n- 
pm run build -w stockpilot-client passes\n- 
pm run test:subscription -w stockpilot-api passes