### PR TITLE
test: customer/loyalty API risk coverage + edge-case hardening

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "test:sso": "ts-node -P tests/tsconfig.json tests/sso.spec.ts",
     "test:subscription": "ts-node -P tests/tsconfig.json tests/subscription.spec.ts",
     "test:tenants": "ts-node -P tests/tsconfig.json tests/tenants.spec.ts",
+    "test:customer-loyalty": "ts-node -r tsconfig-paths/register -P tests/tsconfig.json tests/customer-loyalty.spec.ts",
     "test:currency": "ts-node -P tests/tsconfig.json tests/currency.spec.ts",
     "test:enterprise-ai": "ts-node -P tests/tsconfig.json tests/enterprise-ai.spec.ts",
     "test:enterprise-ai-endpoints": "ts-node -P tests/tsconfig.json tests/enterprise-ai-endpoints.spec.ts",
@@ -46,6 +47,7 @@
     "@types/ws": "^8.5.10",
     "prisma": "^5.10.2",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.4.2"
   }
 }

--- a/apps/api/src/app/api/customers/[id]/loyalty/route.ts
+++ b/apps/api/src/app/api/customers/[id]/loyalty/route.ts
@@ -4,6 +4,27 @@ import { prisma } from '@/lib/prisma'
 import { authenticate, apiError, handleOptions } from '@/lib/auth'
 import { requirePermission } from '@/lib/rbac'
 
+type CustomerDelegate = {
+  findFirst: (args?: Record<string, unknown>) => Promise<unknown>
+  update: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+type LoyaltyLedgerDelegate = {
+  create: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+const customer = (prisma as unknown as { customer: CustomerDelegate }).customer
+const loyaltyLedger = (prisma as unknown as { loyaltyLedger: LoyaltyLedgerDelegate }).loyaltyLedger
+
+function isAuthError(err: unknown): boolean {
+  const message = (err as Error)?.message || ''
+  return (
+    message.includes('No token provided') ||
+    message.includes('jwt') ||
+    message.includes('token')
+  )
+}
+
 const adjustSchema = z.object({
   type: z.enum(['REDEEM', 'ADJUST']),
   points: z.number().int(),
@@ -23,34 +44,35 @@ export async function POST(req: NextRequest, { params }: RouteContext) {
     const tenantId = user.tenantId
     if (!tenantId) return apiError('No tenant context', 400)
 
-    const customer = await prisma.customer.findFirst({
+    const foundCustomer = await customer.findFirst({
       where: { id: params.id, tenantId, archived: false },
     })
-    if (!customer) return apiError('Customer not found', 404)
+    if (!foundCustomer) return apiError('Customer not found', 404)
 
     const body = await req.json()
     const data = adjustSchema.parse(body)
 
     if (data.type === 'REDEEM' && data.points > 0) {
       // Redeeming means deducting — points argument must be positive (we flip it)
-      if (customer.loyaltyPoints < data.points) {
+      if ((foundCustomer as { loyaltyPoints: number }).loyaltyPoints < data.points) {
         return apiError('Insufficient loyalty points', 422)
       }
     }
 
     const delta = data.type === 'REDEEM' ? -Math.abs(data.points) : data.points
-    const balanceBefore = customer.loyaltyPoints
+    const balanceBefore = (foundCustomer as { loyaltyPoints: number }).loyaltyPoints
     const balanceAfter = balanceBefore + delta
 
     if (balanceAfter < 0) return apiError('Resulting balance would be negative', 422)
 
-    const [updated] = await prisma.$transaction([
-      prisma.customer.update({
+    const updated = await prisma.$transaction(async () => {
+      const updatedCustomer = await customer.update({
         where: { id: params.id },
         data: { loyaltyPoints: balanceAfter },
         select: { id: true, loyaltyPoints: true },
-      }),
-      prisma.loyaltyLedger.create({
+      })
+
+      await loyaltyLedger.create({
         data: {
           tenantId,
           customerId: params.id,
@@ -61,12 +83,15 @@ export async function POST(req: NextRequest, { params }: RouteContext) {
           note: data.note || null,
           createdByUserId: user.userId,
         },
-      }),
-    ])
+      })
+
+      return updatedCustomer
+    })
 
     return NextResponse.json({ data: updated })
   } catch (err) {
     if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[LOYALTY POST]', err)
     return apiError('Internal server error', 500)

--- a/apps/api/src/app/api/customers/[id]/route.ts
+++ b/apps/api/src/app/api/customers/[id]/route.ts
@@ -4,6 +4,32 @@ import { prisma } from '@/lib/prisma'
 import { authenticate, apiError, handleOptions } from '@/lib/auth'
 import { requirePermission } from '@/lib/rbac'
 
+type CustomerDelegate = {
+  findFirst: (args?: Record<string, unknown>) => Promise<unknown>
+  update: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+type SaleDelegate = {
+  findMany: (args?: Record<string, unknown>) => Promise<unknown[]>
+}
+
+type LoyaltyLedgerDelegate = {
+  findMany: (args?: Record<string, unknown>) => Promise<unknown[]>
+}
+
+const customer = (prisma as unknown as { customer: CustomerDelegate }).customer
+const sale = (prisma as unknown as { sale: SaleDelegate }).sale
+const loyaltyLedger = (prisma as unknown as { loyaltyLedger: LoyaltyLedgerDelegate }).loyaltyLedger
+
+function isAuthError(err: unknown): boolean {
+  const message = (err as Error)?.message || ''
+  return (
+    message.includes('No token provided') ||
+    message.includes('jwt') ||
+    message.includes('token')
+  )
+}
+
 const updateCustomerSchema = z.object({
   name: z.string().min(1).max(120).optional(),
   phone: z.string().max(40).optional().or(z.literal('')),
@@ -25,7 +51,7 @@ export async function GET(req: NextRequest, { params }: RouteContext) {
     const tenantId = user.tenantId
     if (!tenantId) return apiError('No tenant context', 400)
 
-    const customer = await prisma.customer.findFirst({
+    const foundCustomer = await customer.findFirst({
       where: { id: params.id, tenantId, archived: false },
       select: {
         id: true,
@@ -41,10 +67,10 @@ export async function GET(req: NextRequest, { params }: RouteContext) {
         createdAt: true,
       },
     })
-    if (!customer) return apiError('Customer not found', 404)
+    if (!foundCustomer) return apiError('Customer not found', 404)
 
     // Purchase history (last 20 sales)
-    const sales = await prisma.sale.findMany({
+    const sales = await sale.findMany({
       where: { customerId: params.id, tenantId, archived: false },
       orderBy: { createdAt: 'desc' },
       take: 20,
@@ -66,7 +92,7 @@ export async function GET(req: NextRequest, { params }: RouteContext) {
     })
 
     // Loyalty ledger (last 30 entries)
-    const ledger = await prisma.loyaltyLedger.findMany({
+    const ledger = await loyaltyLedger.findMany({
       where: { customerId: params.id },
       orderBy: { createdAt: 'desc' },
       take: 30,
@@ -82,8 +108,9 @@ export async function GET(req: NextRequest, { params }: RouteContext) {
       },
     })
 
-    return NextResponse.json({ data: { ...customer, purchaseHistory: sales, loyaltyLedger: ledger } })
+    return NextResponse.json({ data: { ...foundCustomer, purchaseHistory: sales, loyaltyLedger: ledger } })
   } catch (err) {
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[CUSTOMER GET]', err)
     return apiError('Internal server error', 500)
@@ -97,13 +124,13 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
     const tenantId = user.tenantId
     if (!tenantId) return apiError('No tenant context', 400)
 
-    const existing = await prisma.customer.findFirst({ where: { id: params.id, tenantId } })
+    const existing = await customer.findFirst({ where: { id: params.id, tenantId } })
     if (!existing) return apiError('Customer not found', 404)
 
     const body = await req.json()
     const patch = updateCustomerSchema.parse(body)
 
-    const updated = await prisma.customer.update({
+    const updated = await customer.update({
       where: { id: params.id },
       data: {
         ...(patch.name !== undefined ? { name: patch.name } : {}),
@@ -130,6 +157,7 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ data: updated })
   } catch (err) {
     if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[CUSTOMER PATCH]', err)
     return apiError('Internal server error', 500)
@@ -143,17 +171,18 @@ export async function DELETE(req: NextRequest, { params }: RouteContext) {
     const tenantId = user.tenantId
     if (!tenantId) return apiError('No tenant context', 400)
 
-    const existing = await prisma.customer.findFirst({ where: { id: params.id, tenantId } })
+    const existing = await customer.findFirst({ where: { id: params.id, tenantId } })
     if (!existing) return apiError('Customer not found', 404)
 
     // Soft delete
-    await prisma.customer.update({
+    await customer.update({
       where: { id: params.id },
       data: { archived: true, updatedBy: user.userId },
     })
 
     return NextResponse.json({ success: true })
   } catch (err) {
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[CUSTOMER DELETE]', err)
     return apiError('Internal server error', 500)

--- a/apps/api/src/app/api/customers/route.ts
+++ b/apps/api/src/app/api/customers/route.ts
@@ -4,6 +4,23 @@ import { prisma } from '@/lib/prisma'
 import { authenticate, apiError, handleOptions } from '@/lib/auth'
 import { requirePermission, isSuperAdmin } from '@/lib/rbac'
 
+type CustomerDelegate = {
+  findMany: (args?: Record<string, unknown>) => Promise<unknown[]>
+  count: (args?: Record<string, unknown>) => Promise<number>
+  create: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+const customer = (prisma as unknown as { customer: CustomerDelegate }).customer
+
+function isAuthError(err: unknown): boolean {
+  const message = (err as Error)?.message || ''
+  return (
+    message.includes('No token provided') ||
+    message.includes('jwt') ||
+    message.includes('token')
+  )
+}
+
 const createCustomerSchema = z.object({
   name: z.string().min(1).max(120),
   phone: z.string().max(40).optional(),
@@ -46,7 +63,7 @@ export async function GET(req: NextRequest) {
     }
 
     const [data, total] = await Promise.all([
-      prisma.customer.findMany({
+      customer.findMany({
         where,
         orderBy: { name: 'asc' },
         skip: (page - 1) * limit,
@@ -64,11 +81,12 @@ export async function GET(req: NextRequest) {
           createdAt: true,
         },
       }),
-      prisma.customer.count({ where }),
+      customer.count({ where }),
     ])
 
     return NextResponse.json({ data, total, page, limit })
   } catch (err) {
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[CUSTOMERS GET]', err)
     return apiError('Internal server error', 500)
@@ -85,7 +103,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const data = createCustomerSchema.parse(body)
 
-    const customer = await prisma.customer.create({
+    const createdCustomer = await customer.create({
       data: {
         tenantId,
         name: data.name,
@@ -109,9 +127,10 @@ export async function POST(req: NextRequest) {
       },
     })
 
-    return NextResponse.json({ data: customer }, { status: 201 })
+    return NextResponse.json({ data: createdCustomer }, { status: 201 })
   } catch (err) {
     if (err instanceof z.ZodError) return NextResponse.json({ error: err.errors }, { status: 422 })
+    if (isAuthError(err)) return apiError('Unauthorized', 401)
     if ((err as Error).message?.includes('Forbidden')) return apiError((err as Error).message, 403)
     console.error('[CUSTOMERS POST]', err)
     return apiError('Internal server error', 500)

--- a/apps/api/src/app/api/sales/route.ts
+++ b/apps/api/src/app/api/sales/route.ts
@@ -177,6 +177,18 @@ export async function POST(req: NextRequest) {
     const grossTotal = subtotals.reduce((s, i) => s + i.subtotal, 0)
     const totalAmount = Math.max(0, grossTotal - data.discount)
 
+    let resolvedCustomerId: string | undefined
+    if (data.customerId) {
+      const customer = await prisma.customer.findFirst({
+        where: { id: data.customerId, tenantId: user.tenantId!, archived: false },
+        select: { id: true },
+      })
+      if (!customer) {
+        return apiError('Customer not found', 422)
+      }
+      resolvedCustomerId = customer.id
+    }
+
     const sale = await prisma.$transaction(async (tx) => {
       // Generate unique sequential receipt number inside the transaction
       const receiptNumber = await generateReceiptNumber(tx, user.tenantId!)
@@ -190,15 +202,6 @@ export async function POST(req: NextRequest) {
             data: { quantity: { decrement: item.quantity } },
           })
         }
-      }
-
-      // Validate customerId belongs to this tenant
-      let resolvedCustomerId: string | undefined = undefined
-      if (data.customerId) {
-        const cust = await tx.customer.findFirst({
-          where: { id: data.customerId, tenantId: user.tenantId!, archived: false },
-        })
-        if (cust) resolvedCustomerId = cust.id
       }
 
       const createdSale = await tx.sale.create({

--- a/apps/api/tests/customer-loyalty.spec.ts
+++ b/apps/api/tests/customer-loyalty.spec.ts
@@ -1,0 +1,414 @@
+import { strict as assert } from 'assert'
+import jwt from 'jsonwebtoken'
+import { NextRequest } from 'next/server'
+import { prisma } from '../src/lib/prisma'
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-access-secret'
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'test-refresh-secret'
+
+type Role = 'SUPER_ADMIN' | 'BUSINESS_ADMIN' | 'SALESPERSON' | 'AGENT'
+
+type TokenArgs = {
+  role?: Role
+  tenantId?: string | null
+  subsidiaryId?: string | null
+  userId?: string
+}
+
+function makeToken(args: TokenArgs = {}): string {
+  const payload = {
+    userId: args.userId || 'u1',
+    email: 'tester@stockpilot.dev',
+    role: args.role || 'BUSINESS_ADMIN',
+    tenantId: args.tenantId === undefined ? 't1' : args.tenantId,
+    subsidiaryId: args.subsidiaryId === undefined ? 's1' : args.subsidiaryId,
+  }
+  return jwt.sign(payload, process.env.JWT_SECRET as string)
+}
+
+function req(method: string, url: string, token?: string, body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+const prismaAny = prisma as any
+
+type Restorer = () => void
+const restorers: Restorer[] = []
+
+function stub(path: string[], value: unknown) {
+  let obj: any = prismaAny
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const key = path[i]
+    if (!obj[key]) obj[key] = {}
+    obj = obj[key]
+  }
+  const leaf = path[path.length - 1]
+  const prev = obj[leaf]
+  obj[leaf] = value
+  restorers.push(() => {
+    obj[leaf] = prev
+  })
+}
+
+function restoreAll() {
+  while (restorers.length) {
+    const fn = restorers.pop()!
+    fn()
+  }
+}
+
+const customersRoute = require('../src/app/api/customers/route') as {
+  GET: (request: NextRequest) => Promise<Response>
+  POST: (request: NextRequest) => Promise<Response>
+}
+const customerDetailRoute = require('../src/app/api/customers/[id]/route') as {
+  GET: (request: NextRequest, context: { params: { id: string } }) => Promise<Response>
+}
+const loyaltyRoute = require('../src/app/api/customers/[id]/loyalty/route') as {
+  POST: (request: NextRequest, context: { params: { id: string } }) => Promise<Response>
+}
+const salesRoute = require('../src/app/api/sales/route') as {
+  POST: (request: NextRequest) => Promise<Response>
+}
+
+async function readJson(res: Response): Promise<any> {
+  return res.json()
+}
+
+async function testCustomerAuthAndValidation() {
+  // Unauthorized should return 401 (not 500)
+  {
+    const response = await customersRoute.GET(req('GET', 'http://localhost:3000/api/customers'))
+    assert.equal(response.status, 401)
+  }
+
+  // AGENT role should be forbidden on customer create
+  {
+    const token = makeToken({ role: 'AGENT', tenantId: 't1' })
+    const response = await customersRoute.POST(
+      req('POST', 'http://localhost:3000/api/customers', token, { name: 'Alice' }),
+    )
+    assert.equal(response.status, 403)
+  }
+
+  // Invalid email should fail schema validation
+  {
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1' })
+    const response = await customersRoute.POST(
+      req('POST', 'http://localhost:3000/api/customers', token, { name: 'Alice', email: 'bad-email' }),
+    )
+    assert.equal(response.status, 422)
+  }
+
+  // SUPER_ADMIN tenant scoping should honor tenantId query parameter
+  {
+    let capturedTenantId: string | null = null
+    stub(['customer', 'findMany'], async (args: any) => {
+      capturedTenantId = args.where.tenantId
+      return []
+    })
+    stub(['customer', 'count'], async () => 0)
+
+    const token = makeToken({ role: 'SUPER_ADMIN', tenantId: null, subsidiaryId: null })
+    const response = await customersRoute.GET(
+      req('GET', 'http://localhost:3000/api/customers?tenantId=t-scope', token),
+    )
+    assert.equal(response.status, 200)
+    assert.equal(capturedTenantId, 't-scope')
+    restoreAll()
+  }
+}
+
+async function testLoyaltyBalanceFloorRules() {
+  // Redeem above balance should be blocked
+  {
+    stub(['customer', 'findFirst'], async () => ({ id: 'c1', loyaltyPoints: 10, tenantId: 't1', archived: false }))
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1' })
+    const response = await loyaltyRoute.POST(
+      req('POST', 'http://localhost:3000/api/customers/c1/loyalty', token, {
+        type: 'REDEEM',
+        points: 20,
+      }),
+      { params: { id: 'c1' } },
+    )
+    assert.equal(response.status, 422)
+    const payload = await readJson(response)
+    assert.equal(payload.error, 'Insufficient loyalty points')
+    restoreAll()
+  }
+
+  // ADJUST negative beyond floor should be blocked
+  {
+    stub(['customer', 'findFirst'], async () => ({ id: 'c1', loyaltyPoints: 5, tenantId: 't1', archived: false }))
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1' })
+    const response = await loyaltyRoute.POST(
+      req('POST', 'http://localhost:3000/api/customers/c1/loyalty', token, {
+        type: 'ADJUST',
+        points: -9,
+      }),
+      { params: { id: 'c1' } },
+    )
+    assert.equal(response.status, 422)
+    const payload = await readJson(response)
+    assert.equal(payload.error, 'Resulting balance would be negative')
+    restoreAll()
+  }
+
+  // Valid redeem should write ledger with negative delta and new balance
+  {
+    const updates: any[] = []
+    const ledgers: any[] = []
+
+    stub(['customer', 'findFirst'], async () => ({ id: 'c1', loyaltyPoints: 12, tenantId: 't1', archived: false }))
+    stub(['customer', 'update'], async (args: any) => {
+      updates.push(args)
+      return { id: 'c1', loyaltyPoints: 7 }
+    })
+    stub(['loyaltyLedger', 'create'], async (args: any) => {
+      ledgers.push(args)
+      return { id: 'l1' }
+    })
+    stub(['$transaction'], async (arg: unknown) => {
+      if (typeof arg === 'function') {
+        return (arg as () => Promise<unknown>)()
+      }
+      return Promise.all(arg as Array<Promise<unknown>>)
+    })
+
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1' })
+    const response = await loyaltyRoute.POST(
+      req('POST', 'http://localhost:3000/api/customers/c1/loyalty', token, {
+        type: 'REDEEM',
+        points: 5,
+        note: 'Cashback promo redemption',
+      }),
+      { params: { id: 'c1' } },
+    )
+    assert.equal(response.status, 200)
+    assert.equal(updates.length, 1)
+    assert.equal(updates[0].data.loyaltyPoints, 7)
+    assert.equal(ledgers.length, 1)
+    assert.equal(ledgers[0].data.points, -5)
+    assert.equal(ledgers[0].data.balanceBefore, 12)
+    assert.equal(ledgers[0].data.balanceAfter, 7)
+    restoreAll()
+  }
+}
+
+async function testSaleLinkedAccrualEdgeCases() {
+  const basePayload = {
+    subsidiaryId: 's1',
+    items: [{ productId: 'p1', quantity: 1, unitPrice: 10.75, costPrice: 4, discount: 0 }],
+    discount: 0,
+    paymentMethod: 'CASH',
+    amountPaid: 10.75,
+    currency: 'USD',
+    fxRate: 1,
+  }
+
+  // Invalid customerId should be rejected explicitly
+  {
+    stub(['subsidiary', 'findFirst'], async () => ({ id: 's1' }))
+    stub(['sale', 'findFirst'], async () => null)
+    stub(['product', 'findMany'], async () => [{ id: 'p1', type: 'GOODS', quantity: 99, name: 'Widget' }])
+    stub(['customer', 'findFirst'], async () => null)
+
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1', subsidiaryId: null })
+    const response = await salesRoute.POST(
+      req('POST', 'http://localhost:3000/api/sales', token, { ...basePayload, customerId: 'missing' }),
+    )
+    assert.equal(response.status, 422)
+    const payload = await readJson(response)
+    assert.equal(payload.error, 'Customer not found')
+    restoreAll()
+  }
+
+  // Positive sale amount should earn floor(total) points and create ledger
+  {
+    const customerUpdates: any[] = []
+    const ledgerEntries: any[] = []
+
+    stub(['subsidiary', 'findFirst'], async () => ({ id: 's1' }))
+    stub(['sale', 'findFirst'], async () => null)
+    stub(['product', 'findMany'], async (args: any) => {
+      if (args?.where?.id) {
+        return [{ id: 'p1', type: 'GOODS', quantity: 99, name: 'Widget', status: 'ACTIVE' }]
+      }
+      return []
+    })
+    stub(['notification', 'findFirst'], async () => ({ id: 'n1' }))
+    stub(['notification', 'create'], async () => ({ id: 'n1' }))
+    stub(['auditLog', 'create'], async () => ({ id: 'a1' }))
+    stub(['customer', 'findFirst'], async (args: any) => {
+      if (args?.select?.id) return { id: 'c1' }
+      return { loyaltyPoints: 4 }
+    })
+
+    const tx = {
+      sale: {
+        count: async () => 0,
+        create: async (_args: any) => ({ id: 'sale-1', receiptNumber: 'RCP-20260412-00001', items: [], user: { firstName: 'A', lastName: 'B' } }),
+      },
+      product: { update: async () => ({}) },
+      customer: {
+        findFirst: async () => ({ loyaltyPoints: 4 }),
+        update: async (args: any) => {
+          customerUpdates.push(args)
+          return { id: 'c1' }
+        },
+      },
+      loyaltyLedger: {
+        create: async (args: any) => {
+          ledgerEntries.push(args)
+          return { id: 'l1' }
+        },
+      },
+    }
+    stub(['$transaction'], async (cb: (client: any) => Promise<unknown>) => cb(tx))
+
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1', subsidiaryId: null })
+    const response = await salesRoute.POST(
+      req('POST', 'http://localhost:3000/api/sales', token, { ...basePayload, customerId: 'c1' }),
+    )
+    assert.equal(response.status, 201)
+    assert.equal(customerUpdates.length, 1)
+    assert.equal(customerUpdates[0].data.loyaltyPoints, 14) // floor(10.75) = 10
+    assert.equal(ledgerEntries.length, 1)
+    assert.equal(ledgerEntries[0].data.points, 10)
+    restoreAll()
+  }
+
+  // Zero-value sale should increment visit/spend but not create loyalty ledger
+  {
+    const customerUpdates: any[] = []
+    const ledgerEntries: any[] = []
+
+    stub(['subsidiary', 'findFirst'], async () => ({ id: 's1' }))
+    stub(['sale', 'findFirst'], async () => null)
+    stub(['product', 'findMany'], async (args: any) => {
+      if (args?.where?.id) {
+        return [{ id: 'p1', type: 'GOODS', quantity: 99, name: 'Widget', status: 'ACTIVE' }]
+      }
+      return []
+    })
+    stub(['notification', 'findFirst'], async () => ({ id: 'n1' }))
+    stub(['notification', 'create'], async () => ({ id: 'n1' }))
+    stub(['auditLog', 'create'], async () => ({ id: 'a1' }))
+    stub(['customer', 'findFirst'], async (args: any) => {
+      if (args?.select?.id) return { id: 'c1' }
+      return { loyaltyPoints: 50 }
+    })
+
+    const tx = {
+      sale: {
+        count: async () => 0,
+        create: async (_args: any) => ({ id: 'sale-2', receiptNumber: 'RCP-20260412-00002', items: [], user: { firstName: 'A', lastName: 'B' } }),
+      },
+      product: { update: async () => ({}) },
+      customer: {
+        findFirst: async () => ({ loyaltyPoints: 50 }),
+        update: async (args: any) => {
+          customerUpdates.push(args)
+          return { id: 'c1' }
+        },
+      },
+      loyaltyLedger: {
+        create: async (args: any) => {
+          ledgerEntries.push(args)
+          return { id: 'l2' }
+        },
+      },
+    }
+    stub(['$transaction'], async (cb: (client: any) => Promise<unknown>) => cb(tx))
+
+    const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1', subsidiaryId: null })
+    const response = await salesRoute.POST(
+      req('POST', 'http://localhost:3000/api/sales', token, {
+        ...basePayload,
+        amountPaid: 0,
+        items: [{ productId: 'p1', quantity: 1, unitPrice: 0, costPrice: 0, discount: 0 }],
+        customerId: 'c1',
+      }),
+    )
+    assert.equal(response.status, 201)
+    assert.equal(customerUpdates.length, 1)
+    assert.equal(customerUpdates[0].data.loyaltyPoints, undefined)
+    assert.equal(ledgerEntries.length, 0)
+    restoreAll()
+  }
+}
+
+async function testCustomerDetailPurchaseAndLedgerRead() {
+  // Ensure the detail endpoint returns both history and ledger payloads for POS targeting use-cases
+  stub(['customer', 'findFirst'], async () => ({
+    id: 'c1',
+    name: 'Ada',
+    phone: null,
+    email: null,
+    address: null,
+    notes: null,
+    loyaltyPoints: 20,
+    totalSpend: 120,
+    visitCount: 3,
+    lastVisitedAt: null,
+    createdAt: new Date().toISOString(),
+  }))
+  stub(['sale', 'findMany'], async () => [
+    {
+      id: 'sale-1',
+      receiptNumber: 'RCP-1',
+      totalAmount: 42,
+      currency: 'USD',
+      paymentMethod: 'CASH',
+      createdAt: new Date().toISOString(),
+      items: [{ quantity: 1, unitPrice: 42, product: { name: 'Widget' } }],
+    },
+  ])
+  stub(['loyaltyLedger', 'findMany'], async () => [
+    {
+      id: 'l1',
+      type: 'EARN',
+      points: 10,
+      balanceBefore: 10,
+      balanceAfter: 20,
+      note: 'Earned',
+      saleId: 'sale-1',
+      createdAt: new Date().toISOString(),
+    },
+  ])
+
+  const token = makeToken({ role: 'BUSINESS_ADMIN', tenantId: 't1' })
+  const response = await customerDetailRoute.GET(
+    req('GET', 'http://localhost:3000/api/customers/c1', token),
+    { params: { id: 'c1' } },
+  )
+  assert.equal(response.status, 200)
+  const payload = await readJson(response)
+  assert.equal(Array.isArray(payload.data.purchaseHistory), true)
+  assert.equal(Array.isArray(payload.data.loyaltyLedger), true)
+  assert.equal(payload.data.purchaseHistory.length, 1)
+  assert.equal(payload.data.loyaltyLedger.length, 1)
+
+  restoreAll()
+}
+
+async function run() {
+  await testCustomerAuthAndValidation()
+  await testLoyaltyBalanceFloorRules()
+  await testSaleLinkedAccrualEdgeCases()
+  await testCustomerDetailPurchaseAndLedgerRead()
+  console.log('customer-loyalty.spec: all assertions passed')
+}
+
+run().catch((err) => {
+  console.error('customer-loyalty.spec failed')
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/api/tests/tsconfig.json
+++ b/apps/api/tests/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/ws": "^8.5.10",
         "prisma": "^5.10.2",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.4.2"
       }
     },
@@ -6746,6 +6747,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -8351,6 +8362,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -8698,6 +8719,21 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",


### PR DESCRIPTION
## What this addresses\nAdds dedicated automated coverage for the remaining high-risk loyalty surfaces:\n- customer CRUD validation and authorization behavior\n- sale-linked loyalty accrual edge cases\n- redemption and balance-floor handling\n\n## Included\n- new test suite: apps/api/tests/customer-loyalty.spec.ts\n- test script wiring + ts-node alias support\n- API hardening:\n  - explicit invalid customer rejection in sales checkout\n  - consistent 401 handling for auth failures in customer/loyalty routes\n  - callback-style transaction compatibility in loyalty route\n\n## Validation\n- npm run test:customer-loyalty -w stockpilot-api\n- npm run test:subscription -w stockpilot-api\n- npm run build -w stockpilot-client\n