### PR TITLE
fix: platform dashboard load failure + API core risk aggregate script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "test:subscription": "ts-node -P tests/tsconfig.json tests/subscription.spec.ts",
     "test:tenants": "ts-node -P tests/tsconfig.json tests/tenants.spec.ts",
     "test:customer-loyalty": "ts-node -r tsconfig-paths/register -P tests/tsconfig.json tests/customer-loyalty.spec.ts",
+    "test:core-risk": "npm run test:rbac && npm run test:jwt && npm run test:subscription && npm run test:customer-loyalty",
     "test:currency": "ts-node -P tests/tsconfig.json tests/currency.spec.ts",
     "test:enterprise-ai": "ts-node -P tests/tsconfig.json tests/enterprise-ai.spec.ts",
     "test:enterprise-ai-endpoints": "ts-node -P tests/tsconfig.json tests/enterprise-ai-endpoints.spec.ts",

--- a/apps/api/src/app/api/reports/platform-stats/route.ts
+++ b/apps/api/src/app/api/reports/platform-stats/route.ts
@@ -8,8 +8,9 @@ function toNumber(value: unknown): number {
   return Number.isFinite(numeric) ? numeric : 0
 }
 
-async function getTransactionToBaseRate(baseTenantId: string, baseCurrency: string, transactionCurrency: string): Promise<number> {
+async function getTransactionToBaseRate(baseTenantId: string | null | undefined, baseCurrency: string, transactionCurrency: string): Promise<number> {
   if (transactionCurrency === baseCurrency) return 1
+  if (!baseTenantId) return 1
 
   const direct = await prisma.currencyRate.findFirst({
     where: { tenantId: baseTenantId, fromCurrency: baseCurrency, toCurrency: transactionCurrency },
@@ -120,6 +121,7 @@ export async function GET(req: NextRequest) {
       ? await prisma.tenant.findUnique({ where: { id: user.tenantId }, select: { baseCurrency: true } })
       : null
     const baseCurrency = platformTenant?.baseCurrency || 'USD'
+    const fxTenantId = user.tenantId || null
 
       // Get total companies (tenants) - exclude the platform owner's own company
       const totalCompanies = await prisma.tenant.count({
@@ -161,10 +163,10 @@ export async function GET(req: NextRequest) {
       )
     )
 
-    const latestRates = billingCurrencies.length > 0
+    const latestRates = fxTenantId && billingCurrencies.length > 0
       ? await prisma.currencyRate.findMany({
           where: {
-            tenantId: user.tenantId!,
+            tenantId: fxTenantId,
             OR: [
               { fromCurrency: baseCurrency, toCurrency: { in: billingCurrencies } },
               { fromCurrency: { in: billingCurrencies }, toCurrency: baseCurrency },
@@ -244,7 +246,7 @@ export async function GET(req: NextRequest) {
       const converted = await Promise.all(rows.map(async (row) => {
         const amount = toNumber(row.amount)
         if (row.currency === baseCurrency) return amount
-        const rate = await getTransactionToBaseRate(user.tenantId!, baseCurrency, row.currency)
+        const rate = await getTransactionToBaseRate(fxTenantId, baseCurrency, row.currency)
         return amount / rate
       }))
       return converted.reduce((sum, val) => sum + val, 0)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:enterprise-ai-endpoints": "npm run test:enterprise-ai-endpoints -w stockpilot-api",
     "test:enterprise-ai-http": "npm run test:enterprise-ai-http -w stockpilot-api",
     "test:enterprise-ai-all": "npm run test:enterprise-ai-all -w stockpilot-api",
+    "test:api-core-risk": "npm run test:core-risk -w stockpilot-api",
     "db:migrate": "npm run db:migrate -w stockpilot-api",
     "db:seed": "npm run db:seed -w stockpilot-api",
     "db:studio": "npm run db:studio -w stockpilot-api"


### PR DESCRIPTION
## Fixes\n- prevents /api/reports/platform-stats from failing when SUPER_ADMIN tenantId is null by guarding FX tenant lookups\n- adds core risk aggregate test scripts for backend and workspace-level execution\n\n## Validation\n- npm run test:api-core-risk (passes)\n